### PR TITLE
Update pip usage example with CS9

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -377,13 +377,15 @@ already contains everything you need.
 Containerfile.baseimage:
 
 ```Dockerfile
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
-# python3.8 runtime, C build dependencies
-RUN dnf -y install \
-        python38 \
-        python38-pip \
-        python38-devel \
+# python3.9 runtime, C build dependencies
+RUN dnf -y install 'dnf-command(config-manager)' && \
+    dnf config-manager --set-enabled crb && \
+    dnf -y install \
+        python3 \
+        python3-pip \
+        python3-devel \
         gcc \
         make \
         libffi-devel \
@@ -424,11 +426,11 @@ RUN source /tmp/cachi2.env && \
     # We're using network isolation => cannot build the cryptography package with Rust
     # (it downloads Rust crates)
     export CRYPTOGRAPHY_DONT_BUILD_RUST=1 && \
-    python3.8 -m pip install -U pip && \
-    python3.8 -m pip install --use-pep517 -r requirements.txt && \
-    python3.8 -m pip install --use-pep517 .
+    python3 -m pip install -U pip && \
+    python3 -m pip install --use-pep517 -r requirements.txt && \
+    python3 -m pip install --use-pep517 .
 
-CMD ["python3.8", "-m", "atomic_reactor.cli.main", "--help"]
+CMD ["python3", "-m", "atomic_reactor.cli.main", "--help"]
 ```
 
 We can then build the image as before while mounting the required Cachi2 data!


### PR DESCRIPTION
CS8 is EOL since May 31 2024 [1], this patch updates the example of pip usage to use CS9.
Plus, we need to enable the CRB repository which provides gobject-introspection-devel.

[1] https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
