### PR TITLE
[git] Force an empty git config upon git command executions within a repository

### DIFF
--- a/hermeto/core/package_managers/gomod.py
+++ b/hermeto/core/package_managers/gomod.py
@@ -34,7 +34,7 @@ from hermeto.core.models.property_semantics import PropertySet
 from hermeto.core.models.sbom import Component
 from hermeto.core.rooted_path import RootedPath
 from hermeto.core.scm import get_repo_id
-from hermeto.core.utils import get_cache_dir, load_json_stream, run_cmd
+from hermeto.core.utils import GIT_PRISTINE_ENV, get_cache_dir, load_json_stream, run_cmd
 from hermeto.interface.logging import EnforcingModeLoggerAdapter
 
 # NOTE: the 'extra' dict is unused right now, but it's a positional argument for the adapter class
@@ -1644,7 +1644,7 @@ def _vendor_changed(context_dir: RootedPath, enforcing_mode: Mode) -> bool:
 
     try:
         # Diffing modules.txt should catch most issues and produce relatively useful output
-        modules_txt_diff = repo.git.diff("--", str(modules_txt))
+        modules_txt_diff = repo.git.diff("--", str(modules_txt), env=GIT_PRISTINE_ENV)
         if modules_txt_diff:
             log.error_or_warn(
                 "%s changed after vendoring:\n%s",
@@ -1655,7 +1655,7 @@ def _vendor_changed(context_dir: RootedPath, enforcing_mode: Mode) -> bool:
             return True
 
         # Show only if files were added/deleted/modified, not the full diff
-        vendor_diff = repo.git.diff("--name-status", "--", str(vendor))
+        vendor_diff = repo.git.diff("--name-status", "--", str(vendor), env=GIT_PRISTINE_ENV)
         if vendor_diff:
             log.error_or_warn(
                 "%s directory changed after vendoring:\n%s",

--- a/hermeto/core/utils.py
+++ b/hermeto/core/utils.py
@@ -18,6 +18,14 @@ from hermeto.core.errors import BaseError
 
 log = logging.getLogger(__name__)
 
+# Force Null configuration for the following git commands to ignore any user configuration
+# - https://git-scm.com/docs/git#Documentation/git.txt-GITCONFIGGLOBAL
+# - https://git-scm.com/docs/git#Documentation/git.txt-GITCONFIGNOSYSTEM
+GIT_PRISTINE_ENV = {
+    "GIT_CONFIG_GLOBAL": "/dev/null",
+    "GIT_CONFIG_NOSYSTEM": "1",
+}
+
 
 class _FastCopyFailedFallback(Exception):
     """Signals a fall back from fast-in kernel copying to regular copy."""

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -54,7 +54,7 @@ from hermeto.core.package_managers.gomod import (
     fetch_gomod_source,
 )
 from hermeto.core.rooted_path import PathOutsideRoot, RootedPath
-from hermeto.core.utils import load_json_stream
+from hermeto.core.utils import GIT_PRISTINE_ENV, load_json_stream
 from tests.common_utils import GIT_REF, write_file_tree
 
 GO_CMD_PATH = "/usr/bin/go"
@@ -1924,8 +1924,8 @@ def repo_remote_with_tag(rooted_tmp_path: RootedPath) -> tuple[RootedPath, Roote
 
     git.Repo.clone_from(remote_repo_path, local_repo_path)
 
-    remote_repo.create_tag("v1.0.0", ref=initial_commit)
-    remote_repo.create_tag("v2.0.0")
+    remote_repo.create_tag("v1.0.0", ref=initial_commit, env=GIT_PRISTINE_ENV),
+    remote_repo.create_tag("v2.0.0", env=GIT_PRISTINE_ENV)
 
     return remote_repo_path, local_repo_path
 


### PR DESCRIPTION
I recently adopted some new global git configuration which happened to break some of our unit tests. While the tests in question definitely deserve changes not to be so tightly coupled to an exact git output, we should also not let git pick up user configuration automatically if we want to keep consuming its output and process it further in our logic.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
