### PR TITLE
fix: gomod: fetch --tags fail

### DIFF
--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -1252,7 +1252,7 @@ class ModuleVersionResolver:
         repo = git.Repo(repo_path)
         commit = repo.commit(repo.rev_parse("HEAD").hexsha)
         try:
-            repo.remote().fetch(force=True, tags=True)
+            repo.remote().fetch(force=True, tags=True, recurse_submodules="no")
         except Exception as ex:
             raise FetchError(
                 f"Failed to fetch the tags on the Git repository ({type(ex).__name__}) "


### PR DESCRIPTION
'git fetch --tags' fails in a Go repository with submodules in a konflux pipeline.
recurse_submodules="no" will prevent this error.

**Context**
When trying to build a Go repository containing at least one submodule with [konflux](https://konflux-ci.dev/), the pipeline would fail during the `prefetch-dependencies` stage, since cahi2 uses `git fetch --tags`. 
Additionally, the error during the konflux (Go repository with submodules) build doesn't happen, when `fetchTags` is enabled, see  this [PR](https://github.com/stolostron/observatorium-operator/pull/261), users will get this error:
```bash
If the issue seems to be on the Cachi2 side, please contact the maintainers.
Unregistering from: subscription.rhsm.redhat.com:443/subscription
System has been unregistered.
```

**Solution**
This is a workaround, since the root cause of the problem wasn't found. Using `--recurse-submodules=no`  prevents this error.

----------------------------------------------

How I tested it:
1. activated cachi2 venv 
2. created temp folder
```bash
mkdir ~/dev
````
3. moved into the ~/dev folder  
 ```bash 
cd ~/dev
```
4. created test.sh file with a konflux git-clone image and arguments based on the PR mentioned above which would clone the Go repository into a local enviroment 
```bash
#!/bin/bash
set -o errexit -o nounset -o pipefail

test_repo_path=${1?Missing argument: path where to clone the test repo}

mkdir -p "$test_repo_path"

podman run --rm -it \
    -v "$(realpath "$test_repo_path"):/test-repo:z" \
    -w "/test-repo" \
    --user root \
    quay.io/konflux-ci/git-clone@sha256:4e53ebd9242f05ca55bfc8d58b3363d8b9d9bc3ab439d9ab76cdbdf5b1fd42d9 \
        -url=https://github.com/jacobbaungard/observatorium-operator \
        -revision=konflux-213-fail-prefetch \
        -submodules=true
````  
5. cloned the repo with:
```bash
./test.sh repo
```
6. moved to repo folder
```bash
cd repo
```
7. ran cachi2 fetch deps
```bash
cachi2 fetch-deps gomod
```

For the first time it failed as expected. After adding recurse_submodules="no", deleting /repo folder and recreating steps from point 5 it worked.
(Note that you have to delete the /repo folder, since running `cachi2 fetch-deps gomod` for the second time works.) 