### PR TITLE
Add Python3.13 to our supported platforms list

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     container:
       image: python:${{ matrix.python-version }}-slim

--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -25,9 +25,7 @@ jobs:
         # We need to install git inside the container otherwise the checkout action will use Git
         # REST API and the .git directory won't be present which fails due to setuptools-scm
         apt-get update && apt-get install --no-install-recommends --no-install-suggests -y git
-        python3 -m pip install --upgrade pip
-        pip install nox
-        pip install tomlkit
+        pip install --upgrade pip nox tomlkit
 
     - uses: actions/checkout@v4
       with:
@@ -67,9 +65,7 @@ jobs:
         # We need to install git inside the container otherwise the checkout action will use Git
         # REST API and the .git directory won't be present which fails due to setuptools-scm
         apt-get update && apt-get install --no-install-recommends --no-install-suggests -y git
-        python3 -m pip install --upgrade pip
-        pip install nox
-        pip install tomlkit
+        pip install --upgrade pip nox tomlkit
 
     - uses: actions/checkout@v4
       with:
@@ -103,9 +99,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install createrepo-c
           python3 -m venv /var/tmp/venv
-          /var/tmp/venv/bin/pip3 install --upgrade pip
-          /var/tmp/venv/bin/pip3 install nox
-          /var/tmp/venv/bin/pip3 install tomlkit
+          /var/tmp/venv/bin/pip3 install --upgrade pip nox tomlkit
 
       - name: add checkout action...
         uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dynamic = ["version"]
 dependencies = [


### PR DESCRIPTION
Python 3.13 has been out for a while, but we couldn't easily integrate with it in our CI due to `createrepo_c` which we depend on is slow with releases and didn't provide a 3.13 wheel (we'd have to build it from scratch in our CI). That has recently changed and there is a 3.13 build available -> enable support for 3.13 and test with it in unit tests.