### PR TITLE
gomod: Print the Git error message a failure to fetch tags happens

### DIFF
--- a/hermeto/core/package_managers/gomod.py
+++ b/hermeto/core/package_managers/gomod.py
@@ -1257,7 +1257,8 @@ class ModuleVersionResolver:
         except Exception as ex:
             raise FetchError(
                 f"Failed to fetch the tags on the Git repository ({type(ex).__name__}) "
-                f"for {repo.working_tree_dir}"
+                f"for {repo.working_tree_dir}: "
+                f"{str(ex)}"
             )
 
         return cls(repo, commit)


### PR DESCRIPTION
This is very useful when troubleshooting these types of errors. Currently, the only printed output is this:

 ```
Error: FetchError: Failed to fetch the tags on the Git repository [...]
```

Which hides the underlying cause.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
