### PR TITLE
cli: Fix help message doc strings constants missing f-string markers

### DIFF
--- a/hermeto/interface/cli.py
+++ b/hermeto/interface/cli.py
@@ -28,8 +28,8 @@ log = logging.getLogger(__name__)
 DEFAULT_SOURCE = "."
 DEFAULT_OUTPUT = f"./{APP_NAME}-output"
 
-FETCH_DEPS_HELP = """\
-    fetch dependencies for supported package managers.
+FETCH_DEPS_HELP = f"""\
+    Fetch dependencies for supported package managers.
 
     \b
     # gomod package in the current directory
@@ -68,7 +68,7 @@ FETCH_DEPS_HELP = """\
     }}'
     """
 
-MERGE_SBOMS_HELP = """\
+MERGE_SBOMS_HELP = f"""\
         Merge two or more SBOMs into one.
 
         \b


### PR DESCRIPTION
Our CLI help messages currently report:

    $ hermeto fetch-deps --help
     Usage: hermeto fetch-deps [OPTIONS] PKG

     fetch dependencies for supported package managers.
     # gomod package in the current directory
     {APP_NAME} fetch-deps gomod
    ...

fixes: 57b9871f9e21327bfbacfac92b64614622ecf001

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
