### PR TITLE
Revert "Rebranding: README.md: Turn on rebranding notice."

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,3 @@
-# 🚧 REBRANDING NOTICE 🚧
-**This project is currently undergoing rebranding
-(see https://github.com/orgs/hermetoproject/discussions/824).**
-
-**You will gradually notice changes to the code base and eventually - the repository name and
-release artifacts. We are taking steps to ensure backwards compatibility, so feel free to continue
-using the project as normal, stay tuned!**
-
 # Hermeto
 
 [![coverage][hermeto-coverage-badge]][hermeto-coverage-status]


### PR DESCRIPTION
This reverts commit ee2da42510f2706000350668151132444c68b7a3.

With the rebranding effort now complete [1], we can drop the rebranding notice from the main README.
[1] https://github.com/orgs/hermetoproject/discussions/872