### PR TITLE
Add a check for invalid path in get_repo_id function

### DIFF
--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -8,7 +8,7 @@ from urllib.parse import urlsplit
 import pytest
 from git.repo import Repo
 
-from hermeto.core.errors import FetchError, UnsupportedFeature
+from hermeto.core.errors import FetchError, PackageRejected, UnsupportedFeature
 from hermeto.core.scm import RepoID, clone_as_tarball, get_repo_id
 
 INITIAL_COMMIT = "78510c591e2be635b010a52a7048b562bad855a3"
@@ -62,6 +62,10 @@ class TestRepoID:
             match="cannot process repositories that don't have an 'origin' remote",
         ):
             get_repo_id(golang_repo_path)
+
+    def test_get_repo_id_invalid_path(self, tmp_path: Path) -> None:
+        with pytest.raises(PackageRejected):
+            get_repo_id(tmp_path)
 
     def test_as_vcs_url_qualifier(self) -> None:
         origin_url = "ssh://git@github.com/foo/bar.git"


### PR DESCRIPTION
Closes: https://github.com/hermetoproject/hermeto/issues/653

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
