### PR TITLE
docs: Clarify .cargo/config.toml setup

### DIFF
--- a/docs/cargo.md
+++ b/docs/cargo.md
@@ -23,18 +23,19 @@ The default output directory is `hermeto-output`. You can change it by passing
 the `--output-dir` option for the `fetch-deps` command. See the help message
 for more information.
 
-After prefetching the dependencies, you can use the prefetched dependencies
-to build your project. Make sure to run the following command to update the
-`.cargo/config.toml` to use them. (If the file does not exist in your repository,
-it will be created).
+After prefetching the dependencies, you can use the `hermeto inject-files` command to update the
+`.cargo/config.toml` file in your project directory. If it does not exist, it will be created. The
+file will contain instructions for Cargo to use the prefetched dependencies when compiling a
+project.
+
+Use the `--for-output-dir` option to specify the location where you want to mount the
+`hermeto-output` in your container build environment. See the next section.
+
+**Do not forget to copy `.cargo/config.toml` when building your container image.**
 
 ```bash
 hermeto inject-files --for-output-dir /tmp/hermeto-output hermeto-output
 ```
-
-Use `--for-output-dir` to specify the output directory you want to mount or copy
-to the container. The command will update the `.cargo/config.toml` file to use the
-prefetched dependencies from the specified directory.
 
 _There are no environment variables that need to be set for the build phase._
 
@@ -49,9 +50,7 @@ FROM docker.io/library/rust:latest
 
 WORKDIR /app
 
-COPY Cargo.toml Cargo.lock .
-
-...
+COPY Cargo.toml Cargo.lock .cargo .
 
 RUN cargo build --release
 ```


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
