### PR TITLE
increase yarn 1.x network timeout to 10 min

### DIFF
--- a/hermeto/core/package_managers/yarn_classic/main.py
+++ b/hermeto/core/package_managers/yarn_classic/main.py
@@ -31,6 +31,7 @@ log = logging.getLogger(__name__)
 
 
 MIRROR_DIR = "deps/yarn-classic"
+YARN_NETWORK_TIMEOUT_MILLISECONDS = 600000
 _yarn_classic_pattern = "yarn lockfile v1"  # See [yarn_classic_trait].
 
 
@@ -131,6 +132,7 @@ def _get_prefetch_environment_variables(output_dir: RootedPath) -> dict[str, str
         "COREPACK_ENABLE_PROJECT_SPEC": "0",
         "YARN_IGNORE_PATH": "true",
         "YARN_IGNORE_SCRIPTS": "true",
+        "YARN_NETWORK_TIMEOUT": f"{YARN_NETWORK_TIMEOUT_MILLISECONDS}",
         "YARN_YARN_OFFLINE_MIRROR": str(output_dir.join_within_root(MIRROR_DIR)),
         "YARN_YARN_OFFLINE_MIRROR_PRUNING": "false",
     }

--- a/tests/unit/package_managers/yarn_classic/test_main.py
+++ b/tests/unit/package_managers/yarn_classic/test_main.py
@@ -13,6 +13,7 @@ from hermeto.core.models.output import BuildConfig, EnvironmentVariable, Request
 from hermeto.core.models.sbom import Component
 from hermeto.core.package_managers.yarn_classic.main import (
     MIRROR_DIR,
+    YARN_NETWORK_TIMEOUT_MILLISECONDS,
     _fetch_dependencies,
     _generate_build_environment_variables,
     _get_prefetch_environment_variables,
@@ -190,6 +191,7 @@ def test_get_prefetch_environment_variables(tmp_path: Path) -> None:
         "COREPACK_ENABLE_PROJECT_SPEC": "0",
         "YARN_IGNORE_PATH": "true",
         "YARN_IGNORE_SCRIPTS": "true",
+        "YARN_NETWORK_TIMEOUT": f"{YARN_NETWORK_TIMEOUT_MILLISECONDS}",
         "YARN_YARN_OFFLINE_MIRROR": str(yarn_deps_dir),
         "YARN_YARN_OFFLINE_MIRROR_PRUNING": "false",
     }


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Docs updated (if applicable)
- [n/a] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
