### PR TITLE
chore: Make pip skip Rust sources when binaries allowed

### DIFF
--- a/hermeto/core/package_managers/pip.py
+++ b/hermeto/core/package_managers/pip.py
@@ -229,6 +229,7 @@ def fetch_pip_source(request: Request) -> RequestOutput:
         environment_variables=environment_variables,
         project_files=project_files,
     )
+
     cargo_packages = _find_and_fetch_rust_dependencies(request, packages_containing_rust_code)
     return pip_packages + cargo_packages
 
@@ -2190,9 +2191,13 @@ def _resolve_pip(
         output_dir, resolved_build_req_files, allow_binary
     )
 
-    packages_containing_rust_code = _filter_packages_with_rust_code(
-        requires + build_requires, output_dir, source_dir
-    )
+    # No need to search for Rust code when a user requested just binaries.
+    if allow_binary:
+        packages_containing_rust_code = []
+    else:
+        packages_containing_rust_code = _filter_packages_with_rust_code(
+            requires + build_requires, output_dir, source_dir
+        )
 
     # Mark all build dependencies as such
     for dependency in build_requires:


### PR DESCRIPTION
Previously pip would download and process Rust sources even when a user requested just binaries. This change introduces a check to skip Rust sources processing when a user is fine with having just binaries.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
