### PR TITLE
chore: Improve messaging for corrupt Cargo.locks

### DIFF
--- a/docs/pip.md
+++ b/docs/pip.md
@@ -511,6 +511,15 @@ Note, that a system which is to be used for building these extensions must have
 With these preparations running a pip installation as usual should be sufficient to
 build and install a Rust-based extension.
 
+Note, that sometimes Rust-based extensions can break a build. This could happen when
+such dependency is distributed with a Cargo.lock not matching Cargo.toml (while rare this seems
+to happen due to peculiarities of the release process for some packages). In this case
+a package will be rejected with a note about lock file mismatch and an additional report from
+Cargo about inability to load package lock file due to a mismatch. There is no
+good solution for this problem on Hermeto's side and the best course of action is to reach out
+to maintainers of this extension and notify them about the mismatch. Switching to a binary
+distribution of the package would also resolve this problem at the price of not building
+it from sources (see [Building with wheels](#building-with-wheels) for additional context).
 
 ## Troubleshooting
 


### PR DESCRIPTION
When a Cargo.lock and Cargo.toml do not match `cargo vendor --locked` will refuse to proceed. This is a corner case which manifests itself in several Python packages extended with Rust. While making sure that locks match to configs is not a direct responsibility of Hermeto the messaging around this specific failure was confusing.

This change adds a dedicated exception class to raise when there is a mismatch which contains a more thorough explanation of the problem.

Adds visibility to https://github.com/hermetoproject/hermeto/issues/925

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
