### PR TITLE
Konflux onboarding: Add a dedicated Konflux Dockerfile

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -6,3 +6,4 @@
 !pyproject.toml
 !requirements.txt
 !MANIFEST.in
+!.konflux/requirements-build.txt

--- a/.konflux/Dockerfile.konflux
+++ b/.konflux/Dockerfile.konflux
@@ -1,0 +1,85 @@
+# This file is meant to be built hermetically in a Konflux instance.
+# It can only be build locally if the prefetching of dependencies is properly configured.
+
+FROM registry.access.redhat.com/ubi9/ubi@sha256:a1804302f6f53e04cc1c6b20bc2204d5c9ae6e5a664174b38fbeeb30f7983d4e as ubi
+
+###########################
+# PREPARE GENERIC ARTIFACTS
+###########################
+FROM ubi as artifacts
+
+RUN mkdir /artifacts && \
+    cd /artifacts && \
+    mkdir go1.20 go1.21 nodejs && \
+    # Assume that the Hermeto prefetched content will be mounted to /cachi2/output
+    tar -xzf /cachi2/output/deps/generic/go1.20.linux-amd64.tar.gz -C ./go1.20 && \
+    tar -xzf /cachi2/output/deps/generic/go1.21.0.linux-amd64.tar.gz -C ./go1.21 && \
+    # Use --strip-components to change the default nodejs-{version}-{os}-{arch} naming schema
+    tar -xzf /cachi2/output/deps/generic/nodejs.tar.gz -C ./nodejs --strip-components 1
+
+########################
+# PREPARE OUR BASE IMAGE
+########################
+FROM ubi as base
+RUN dnf -y install \
+    --setopt install_weak_deps=0 \
+    --nodocs \
+    git-core \
+    jq \
+    python3 \
+    rubygem-bundler \
+    rubygem-json \
+    subscription-manager && \
+    dnf clean all
+
+###############
+# BUILD/INSTALL
+###############
+FROM base as builder
+WORKDIR /src
+RUN dnf -y install \
+    --setopt install_weak_deps=0 \
+    --nodocs \
+    gcc \
+    # not a build dependency, but we copy the binary to the final image
+    cargo \
+    python3-devel \
+    python3-pip \
+    python3-setuptools \
+    && dnf clean all
+
+# Install dependencies in a separate layer to maximize layer caching
+COPY requirements.txt .
+COPY .konflux/requirements-build.txt requirements-build.txt
+
+RUN python3 -m venv /venv && \
+    /venv/bin/pip install --upgrade pip && \
+    /venv/bin/pip install -r requirements.txt --no-deps --no-cache-dir --require-hashes
+
+COPY . .
+RUN /venv/bin/pip install setuptools && \
+    /venv/bin/pip install --no-cache-dir .
+
+##########################
+# ASSEMBLE THE FINAL IMAGE
+##########################
+FROM base
+LABEL maintainer="Red Hat"
+
+# copy Go SDKs and Node.js installation from official images
+COPY --from=artifacts /artifacts/go1.20/go /usr/local/go/go1.20
+COPY --from=artifacts /artifacts/go1.21/go /usr/local/go/go1.21
+COPY --from=artifacts /artifacts/nodejs/lib/node_modules/corepack/dist/corepack.js /usr/local/lib/corepack
+COPY --from=artifacts /artifacts/nodejs/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/node
+COPY --from=builder /usr/bin/cargo /usr/bin/cargo
+COPY --from=builder /venv /venv
+
+# link corepack, yarn, and go to standard PATH location
+RUN ln -s /usr/local/lib/corepack/dist/corepack.js /usr/local/bin/corepack && \
+    ln -s /usr/local/lib/corepack/dist/yarn.js /usr/local/bin/yarn && \
+    ln -s /usr/local/go/go1.21/bin/go /usr/local/bin/go && \
+    ln -s /venv/bin/createrepo_c /usr/local/bin/createrepo_c && \
+    ln -s /venv/bin/cachi2 /usr/local/bin/cachi2 && \
+    ln -s /venv/bin/hermeto /usr/local/bin/hermeto
+
+ENTRYPOINT ["/usr/local/bin/hermeto"]

--- a/.konflux/artifacts.lock.yaml
+++ b/.konflux/artifacts.lock.yaml
@@ -1,0 +1,10 @@
+metadata:
+  version: "1.0"
+artifacts:
+  - download_url: "https://dl.google.com/go/go1.20.linux-amd64.tar.gz"
+    checksum: "sha256:5a9ebcc65c1cce56e0d2dc616aff4c4cedcfbda8cc6f0288cc08cda3b18dcbf1"
+  - download_url: "https://dl.google.com/go/go1.21.0.linux-amd64.tar.gz"
+    checksum: "sha256:d0398903a16ba2232b389fb31032ddf57cac34efda306a0eebac34f0965a0742"
+  - download_url: "https://nodejs.org/download/release/v23.11.0/node-v23.11.0-linux-x64.tar.gz"
+    checksum: "sha256:66f768a7f2d89ecdda8fe1e33ee71ac04ed9180111cbf1c5fb944655fe7c90c7"
+    filename: "nodejs.tar.gz"

--- a/.konflux/requirements-build.txt
+++ b/.konflux/requirements-build.txt
@@ -1,0 +1,2 @@
+setuptools==78.1.0
+setuptools-scm==8.2.0

--- a/.konflux/rpms.in.yaml
+++ b/.konflux/rpms.in.yaml
@@ -1,0 +1,25 @@
+contentOrigin:
+  # This file is copied from the Dockerfile referenced in the context section.
+  # The repoids have been changed to include the architecture, for compliance reasons:
+  #
+  # ubi-9-baseos-debug-rpms > ubi-9-for-x86_64-baseos-debug-rpms
+  repofiles:
+    - ./ubi.repo
+packages:
+  - cargo
+  - git-core
+  - gcc
+  - jq
+  - python3
+  - python3-pip
+  - python3-setuptools
+  - python3-devel
+  - rubygem-bundler
+  - rubygem-json
+  - subscription-manager
+context:
+  # When resolving the packages, use the image defined in this specific stage of the
+  # referenced Dockerfile
+  containerfile:
+    file: Dockerfile.konflux
+    stageName: ubi

--- a/.konflux/rpms.lock.yaml
+++ b/.konflux/rpms.lock.yaml
@@ -1,0 +1,351 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: x86_64
+  packages:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cargo-1.84.1-1.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 8292467
+    checksum: sha256:7dd011cd79a635654ade4e3186c5f7545d692de81157d1ce1d42656eaa6993b2
+    name: cargo
+    evr: 1.84.1-1.el9
+    sourcerpm: rust-1.84.1-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/c/cpp-11.5.0-5.el9_5.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 11229073
+    checksum: sha256:b5567c690d46d4f5a2cb13be6a4f962dbe8cc7e821b9d3baa09a4f10c59014d9
+    name: cpp
+    evr: 11.5.0-5.el9_5
+    sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/gcc-11.5.0-5.el9_5.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 34006000
+    checksum: sha256:03c99bc1021dbe54dd93120ed6b5249bbb02dbd5da9e0dc5d8c4a21d674fb1fd
+    name: gcc
+    evr: 11.5.0-5.el9_5
+    sourcerpm: gcc-11.5.0-5.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/git-core-2.47.1-2.el9_6.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 4947862
+    checksum: sha256:ae898605cf906ea73181921224143895e20a6eca5df56e8b092bc78e634cb09f
+    name: git-core
+    evr: 2.47.1-2.el9_6
+    sourcerpm: git-2.47.1-2.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-devel-2.34-168.el9_6.14.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 35566
+    checksum: sha256:1565ca914cb58037fc9f50af64be3a43d5ae854b5d30f01882eb06d57c44d52c
+    name: glibc-devel
+    evr: 2.34-168.el9_6.14
+    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/g/glibc-headers-2.34-168.el9_6.14.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 554474
+    checksum: sha256:10579e7e1a0140841209c023fdb9034aae1b3723ab5807f6e6c61e8dd2dbffa7
+    name: glibc-headers
+    evr: 2.34-168.el9_6.14
+    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/j/jq-1.6-15.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 194271
+    checksum: sha256:d3157267cce88006c2ad3327ea7eb8983bea6f69327c157228b89814a3c473ae
+    name: jq
+    evr: 1.6-15.el9
+    sourcerpm: jq-1.6-15.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/k/kernel-headers-5.14.0-570.18.1.el9_6.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 3681841
+    checksum: sha256:67dd8cdd0ad69f0fff631da9cbd14c3de0a92d1c1f42c9bd65b0ae9cc2659f7a
+    name: kernel-headers
+    evr: 5.14.0-570.18.1.el9_6
+    sourcerpm: kernel-5.14.0-570.18.1.el9_6.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libmpc-1.2.1-4.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 66075
+    checksum: sha256:b97b4e98c3c6f41dcfc2ceb4ffa1aba7a338b7cfd9e6c4f63e3160dd3cc033d3
+    name: libmpc
+    evr: 1.2.1-4.el9
+    sourcerpm: libmpc-1.2.1-4.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libxcrypt-compat-4.4.18-3.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 93189
+    checksum: sha256:2bd6c288e1970a001d3a1ae69166c0d926d9c87ce892edcb2110f4e142c12a7a
+    name: libxcrypt-compat
+    evr: 4.4.18-3.el9
+    sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/libxcrypt-devel-4.4.18-3.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 33101
+    checksum: sha256:c1d171391a7d2e043a6953efd3df3e01edc9b4c6cdb54517e1608d204a5fce18
+    name: libxcrypt-devel
+    evr: 4.4.18-3.el9
+    sourcerpm: libxcrypt-4.4.18-3.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/l/llvm-libs-19.1.7-2.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 30399454
+    checksum: sha256:168c8d2d7ed92d3a77c2d8ba898b3506a483a623674072d057606cb29d2e3b87
+    name: llvm-libs
+    evr: 19.1.7-2.el9
+    sourcerpm: llvm-19.1.7-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/o/oniguruma-6.9.6-1.el9.5.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 226331
+    checksum: sha256:6c884cc2216e5b4699ebd8cde27b39e99532520b367f645ed6cc660d081916dc
+    name: oniguruma
+    evr: 6.9.6-1.el9.5
+    sourcerpm: oniguruma-6.9.6-1.el9.5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-devel-3.9.21-2.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 254681
+    checksum: sha256:3470394095fcb7079814ba5714c901e0cbca642839e31ce6b1a22c7cd8e24bb5
+    name: python3-devel
+    evr: 3.9.21-2.el9
+    sourcerpm: python3.9-3.9.21-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/p/python3-pip-21.3.1-1.el9.noarch.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 2133958
+    checksum: sha256:2ff41d5bbfb5bf09378a499b56d9854e9389e3a8648897426d144f4b385f8730
+    name: python3-pip
+    evr: 21.3.1-1.el9
+    sourcerpm: python-pip-21.3.1-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/ruby-3.0.7-165.el9_5.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 40261
+    checksum: sha256:3efe1d022b580d04b9a321990740bcc18b04ce1288a7c3985d74582e24e564e5
+    name: ruby
+    evr: 3.0.7-165.el9_5
+    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/ruby-default-gems-3.0.7-165.el9_5.noarch.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 43707
+    checksum: sha256:87980d39f679983122cfa4dfc385a10623d07471af660146eb03efaff522acf6
+    name: ruby-default-gems
+    evr: 3.0.7-165.el9_5
+    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/ruby-libs-3.0.7-165.el9_5.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 3461571
+    checksum: sha256:3e5da47b7d1e12b6d51a11af40f239f7bf7fcd148670efa25c1beb49431e6e98
+    name: ruby-libs
+    evr: 3.0.7-165.el9_5
+    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rubygem-bigdecimal-3.0.0-165.el9_5.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 53767
+    checksum: sha256:4b44966556dcd4488deb754f152d19b9a3c38c827cb98a13593cf6b36b8441a2
+    name: rubygem-bigdecimal
+    evr: 3.0.0-165.el9_5
+    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rubygem-bundler-2.2.33-165.el9_5.noarch.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 463714
+    checksum: sha256:40a31a95f07540da676a46f96cdf03bb1f16bbc3b50a809cf0c1036dccff5fd9
+    name: rubygem-bundler
+    evr: 2.2.33-165.el9_5
+    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rubygem-io-console-0.5.7-165.el9_5.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 24121
+    checksum: sha256:ad35f8e56ede1cdd9d2df7734c43288cfcd7ad4b2b891ef89b3c2f92e6bdcd08
+    name: rubygem-io-console
+    evr: 0.5.7-165.el9_5
+    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rubygem-json-2.5.1-165.el9_5.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 57752
+    checksum: sha256:ef59f0eeb3eac1836d6cfe9df4c4df19b15332a07a9aa52e20c319d299618f8e
+    name: rubygem-json
+    evr: 2.5.1-165.el9_5
+    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rubygem-psych-3.3.2-165.el9_5.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 58369
+    checksum: sha256:2d8d5482edb3d7d81f948d3c03c7eb74c523911f782a6ea65cd00658089328d4
+    name: rubygem-psych
+    evr: 3.3.2-165.el9_5
+    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rubygem-rdoc-6.3.4.1-165.el9_5.noarch.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 447643
+    checksum: sha256:e10f7a41570c647f3fdfff59cf160036e80e48fc027a92dd624e37a31fda5766
+    name: rubygem-rdoc
+    evr: 6.3.4.1-165.el9_5
+    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rubygems-3.2.33-165.el9_5.noarch.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 310195
+    checksum: sha256:03ae5e148b2be4c5a0fac3cb3cbfe3895f56cf67aa9212f6f28665589caf10e6
+    name: rubygems
+    evr: 3.2.33-165.el9_5
+    sourcerpm: ruby-3.0.7-165.el9_5.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rust-1.84.1-1.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 28050444
+    checksum: sha256:9ba3c53fd811af2f294e31360d75e33e4cb89893130c7b3fe0c6191e20a09f3e
+    name: rust
+    evr: 1.84.1-1.el9
+    sourcerpm: rust-1.84.1-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/appstream/os/Packages/r/rust-std-static-1.84.1-1.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-appstream-rpms
+    size: 41211472
+    checksum: sha256:73bb90884432e2b43758f1043f107a570b5d54b38f17d5d0af51bac103ceb4f5
+    name: rust-std-static
+    evr: 1.84.1-1.el9
+    sourcerpm: rust-1.84.1-1.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-2.35.2-63.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 4818636
+    checksum: sha256:4eb918b63dee7daf32117df2e3fcb02ad4ba3d96cb25677cf55315deceb7e22a
+    name: binutils
+    evr: 2.35.2-63.el9
+    sourcerpm: binutils-2.35.2-63.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/b/binutils-gold-2.35.2-63.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 753176
+    checksum: sha256:339d9bb2dc0e41c4756f1a4f82e82f6654818b72de74f1f0377c76277617352b
+    name: binutils-gold
+    evr: 2.35.2-63.el9
+    sourcerpm: binutils-2.35.2-63.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.192-5.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 47282
+    checksum: sha256:e5b1a7a9e1467bfe00913e9b22ba5665852f8c61900205a32d3043ace9e1c7c2
+    name: elfutils-debuginfod-client
+    evr: 0.192-5.el9
+    sourcerpm: elfutils-0.192-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-libelf-0.192-5.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 212505
+    checksum: sha256:20ef8ae38ec86e43d0adc5b8473bb8feeb880467dfda93f37f0d362ba06a79bc
+    name: elfutils-libelf
+    evr: 0.192-5.el9
+    sourcerpm: elfutils-0.192-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/e/elfutils-libs-0.192-5.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 270058
+    checksum: sha256:a72237e0bffd7ae464d4c0eb7707947a611dc96a667409c7c4a0e73e75cc4ebc
+    name: elfutils-libs
+    evr: 0.192-5.el9
+    sourcerpm: elfutils-0.192-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-2.34-168.el9_6.14.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 2054217
+    checksum: sha256:de8eb45949d4471b59305346c1b55c156fcb0c2b82dab524aa09bef1a0307e69
+    name: glibc
+    evr: 2.34-168.el9_6.14
+    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-common-2.34-168.el9_6.14.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 311029
+    checksum: sha256:df87055efc323b9d82297ca62d1e9c5b23dde42feae85bb568f583ed93bdfe19
+    name: glibc-common
+    evr: 2.34-168.el9_6.14
+    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-langpack-en-2.34-168.el9_6.14.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 673114
+    checksum: sha256:5506c3bd19654bfa4e44f7a4415e624cb35dedad21f7340fb75f615b6f891f6e
+    name: glibc-langpack-en
+    evr: 2.34-168.el9_6.14
+    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/g/glibc-minimal-langpack-2.34-168.el9_6.14.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 19997
+    checksum: sha256:e33e3151973289f4cdccf2ec13ebe63325609a60d4502a399707545866917d2c
+    name: glibc-minimal-langpack
+    evr: 2.34-168.el9_6.14
+    sourcerpm: glibc-2.34-168.el9_6.14.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/less-590-5.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 170758
+    checksum: sha256:a726061c966a134a5e5b42b60e4162ee85a2cef8843b6fd28e08264ceebb54f4
+    name: less
+    evr: 590-5.el9
+    sourcerpm: less-590-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libcbor-0.7.0-5.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 60575
+    checksum: sha256:588e8736af3376abfb3cdf372c10baef02c40d916a55958f3bee9767f9ad8526
+    name: libcbor
+    evr: 0.7.0-5.el9
+    sourcerpm: libcbor-0.7.0-5.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libedit-3.1-38.20210216cvs.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 109330
+    checksum: sha256:9e41ff5754a5dca1308adf9617828934d56cb60d8d08f128f80e4328f69bc78c
+    name: libedit
+    evr: 3.1-38.20210216cvs.el9
+    sourcerpm: libedit-3.1-38.20210216cvs.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libfido2-1.13.0-2.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 102746
+    checksum: sha256:6da940c0528f3e4453db84cb85b402c8f4293a197b1921158df9651edb4845e0
+    name: libfido2
+    evr: 1.13.0-2.el9
+    sourcerpm: libfido2-1.13.0-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/l/libpkgconf-1.7.3-10.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 38387
+    checksum: sha256:4feae5941b73640bd86b8d506a657cac5b770043db1464fbcd207721b2159dda
+    name: libpkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/m/make-4.3-8.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 553896
+    checksum: sha256:561f0c2251e9217c81a6c88de4d2d9231a039aaab37e8a0d2559d36ce9fa85fd
+    name: make
+    evr: 1:4.3-8.el9
+    sourcerpm: make-4.3-8.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssh-8.7p1-45.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 474534
+    checksum: sha256:d43f19d3e736943bdadbda47db016e9da81ce1900f50ecfe470f7a8bc9bce243
+    name: openssh
+    evr: 8.7p1-45.el9
+    sourcerpm: openssh-8.7p1-45.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/o/openssh-clients-8.7p1-45.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 735750
+    checksum: sha256:309d1c9c176bf35b494c8b31a0f3eeceddd0b27be1dfc9defbe9838b9d5a707c
+    name: openssh-clients
+    evr: 8.7p1-45.el9
+    sourcerpm: openssh-8.7p1-45.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-1.7.3-10.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 45675
+    checksum: sha256:bb47b4ecc499c308f41031a99e723827d152d5d750f59849d0c265d820944a26
+    name: pkgconf
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-m4-1.7.3-10.el9.noarch.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 16054
+    checksum: sha256:91bafd6e06099451f60288327b275cfcc651822f6145176a157c6b0fa5131e02
+    name: pkgconf-m4
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/pkgconf-pkg-config-1.7.3-10.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 12438
+    checksum: sha256:9a502d81d73d3303ceb53a06ad7ce525c97117ea64352174a33708bf3429283d
+    name: pkgconf-pkg-config
+    evr: 1.7.3-10.el9
+    sourcerpm: pkgconf-1.7.3-10.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-3.9.21-2.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 30481
+    checksum: sha256:65c73ac98cfbd459b1b9672da58f4e7cf89b6ad979717aa9912ebbed7242a944
+    name: python3
+    evr: 3.9.21-2.el9
+    sourcerpm: python3.9-3.9.21-2.el9.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/x86_64/baseos/os/Packages/p/python3-libs-3.9.21-2.el9.x86_64.rpm
+    repoid: ubi-9-for-x86_64-baseos-rpms
+    size: 8477687
+    checksum: sha256:7d1a15f4540d24ce9e3c17fbfa9850e1ce87c41993b94931a85f1fcfda7eefdd
+    name: python3-libs
+    evr: 3.9.21-2.el9
+    sourcerpm: python3.9-3.9.21-2.el9.src.rpm
+  source: []
+  module_metadata: []

--- a/.konflux/ubi.repo
+++ b/.konflux/ubi.repo
@@ -1,0 +1,62 @@
+[ubi-9-for-x86_64-baseos-rpms]
+name = Red Hat Universal Base Image 9 (RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-9-for-x86_64-baseos-debug-rpms]
+name = Red Hat Universal Base Image 9 (Debug RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-9-for-x86_64-baseos-source-rpms]
+name = Red Hat Universal Base Image 9 (Source RPMs) - BaseOS
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/baseos/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-9-for-x86_64-appstream-rpms]
+name = Red Hat Universal Base Image 9 (RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-9-for-x86_64-appstream-debug-rpms]
+name = Red Hat Universal Base Image 9 (Debug RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-9-for-x86_64-appstream-source-rpms]
+name = Red Hat Universal Base Image 9 (Source RPMs) - AppStream
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/appstream/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-9-for-x86_64-codeready-builder-rpms]
+name = Red Hat Universal Base Image 9 (RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/codeready-builder/os
+enabled = 1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-9-for-x86_64-codeready-builder-debug-rpms]
+name = Red Hat Universal Base Image 9 (Debug RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/codeready-builder/debug
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1
+
+[ubi-9-for-x86_64-codeready-builder-source-rpms]
+name = Red Hat Universal Base Image 9 (Source RPMs) - CodeReady Builder
+baseurl = https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9/$basearch/codeready-builder/source/SRPMS
+enabled = 0
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+gpgcheck = 1


### PR DESCRIPTION
This PR will introduce a new Dockerfile that will be used in the future to enable Konflux builds. For now, this Dockerfile will have no effect in the repository, and it is worth mentioning that it can't be built locally without quite a few specific configurations. 

I tried to keep all the files that are Konflux-specific under the `.konflux` directory, so we can easily move them out in the future in case we decide to do so. Let me know if you agree with this approach.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
