### PR TITLE
cli: Add global mode option for input validation strictness

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ You might also like to check out `hermeto --help` and the `--help` texts of the 
 
 ## Configuration
 
+### Modes
+
+Hermeto can be run in two modes using the global CLI option `--mode`.
+
+* strict
+* permissive
+
+The default mode is `strict`. In this mode, _some_ input requirements that are not met are treated
+as errors. On the other hand, the `permissive` mode treats them as warnings. This means that Hermeto
+will proceed and generate an SBOM, but it may not be complete or accurate.
+
+### Available configuration parameters
+
 You can change Hermeto's configuration by specifying a configuration file while invoking any of the CLI commands:
 
 ```shell
@@ -106,8 +119,6 @@ Any parameter specified in this file will override the default values present in
 [config.py](https://github.com/hermetoproject/hermeto/blob/main/hermeto/core/config.py) module.
 
 The only supported format for the config file is YAML.
-
-### Available configuration parameters
 
 * `default_environment_variables` - a dictionary where the keys
 are names of package managers. The values are dictionaries where the keys

--- a/hermeto/core/models/input.py
+++ b/hermeto/core/models/input.py
@@ -1,3 +1,4 @@
+import enum
 import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Callable, Dict, Literal, Optional, TypeVar, Union
@@ -60,6 +61,13 @@ Flag = Literal[
 ]
 
 
+class Mode(str, enum.Enum):
+    """Represents a global CLI option to relax input expectations and requirements checks."""
+
+    STRICT = "strict"
+    PERMISSIVE = "permissive"
+
+
 class _PackageInputBase(pydantic.BaseModel, extra="forbid"):
     """Common input attributes accepted for all package types."""
 
@@ -100,7 +108,6 @@ class SSLOptions(pydantic.BaseModel, extra="forbid"):
 
     @pydantic.model_validator(mode="after")
     def _validate_ssl_options(self) -> Self:
-
         cert_and_key = (self.client_cert, self.client_key)
         if any(cert_and_key) and not all(cert_and_key):
             raise ValueError(
@@ -254,6 +261,7 @@ class Request(pydantic.BaseModel):
     output_dir: RootedPath
     packages: list[PackageInput]
     flags: frozenset[Flag] = frozenset()
+    mode: Mode = Mode.STRICT
 
     @pydantic.field_validator("packages")
     def _unique_packages(cls, packages: list[PackageInput]) -> list[PackageInput]:

--- a/tests/unit/models/test_input.py
+++ b/tests/unit/models/test_input.py
@@ -9,6 +9,7 @@ import pytest as pytest
 from hermeto.core.errors import InvalidInput
 from hermeto.core.models.input import (
     GomodPackageInput,
+    Mode,
     NpmPackageInput,
     PackageInput,
     PipPackageInput,
@@ -315,6 +316,7 @@ class TestRequest:
                 },
             ],
             "flags": frozenset(),
+            "mode": Mode.STRICT,
         }
         assert isinstance(request.source_dir, RootedPath)
         assert isinstance(request.output_dir, RootedPath)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -181,6 +181,31 @@ class TestTopLevelOpts:
             assert error_expectation in result.output
 
     @pytest.mark.parametrize(
+        "mode",
+        [
+            "strict",
+            "permissive",
+        ],
+    )
+    def test_mode_option_is_valid(self, mode: str) -> None:
+        args = ["--mode", mode, "fetch-deps", "gomod"]
+        with mock_fetch_deps():
+            invoke_expecting_sucess(app, args)
+
+    @pytest.mark.parametrize(
+        "mode",
+        [
+            "bad",
+            "ugly",
+        ],
+    )
+    def test_mode_option_is_not_valid(self, mode: str) -> None:
+        args = ["--mode", mode, "fetch-deps", "gomod"]
+        with mock_fetch_deps():
+            result = invoke_expecting_invalid_usage(app, args)
+            assert f"Invalid value for '--mode': '{mode}' is not one of" in result.output
+
+    @pytest.mark.parametrize(
         "loglevel_args, expected_level",
         [
             ([], "INFO"),


### PR DESCRIPTION
Closes: https://github.com/hermetoproject/hermeto/issues/934

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
