### PR TITLE
ignore yarnPath for yarn v2+ during version check

### DIFF
--- a/hermeto/core/package_managers/yarn/utils.py
+++ b/hermeto/core/package_managers/yarn/utils.py
@@ -87,7 +87,9 @@ class VersionsRange:
 
 def extract_yarn_version_from_env(source_dir: RootedPath, env: Optional[dict] = None) -> Version:
     """Extract yarn version from environment."""
-    env = {"COREPACK_ENABLE_DOWNLOAD_PROMPT": "0"} if env is None else env
+    env = (
+        {"COREPACK_ENABLE_DOWNLOAD_PROMPT": "0", "YARN_IGNORE_PATH": "true"} if env is None else env
+    )
     yarn_version_output = run_yarn_cmd(["--version"], source_dir, env=env).strip()
 
     try:

--- a/tests/unit/package_managers/yarn/test_main.py
+++ b/tests/unit/package_managers/yarn/test_main.py
@@ -140,7 +140,9 @@ def test_corepack_installed_correct_yarn_version(
 
     _verify_corepack_yarn_version(expected_yarn_version, rooted_tmp_path)
     mock_run_yarn_cmd.assert_called_once_with(
-        ["--version"], rooted_tmp_path, env={"COREPACK_ENABLE_DOWNLOAD_PROMPT": "0"}
+        ["--version"],
+        rooted_tmp_path,
+        env={"COREPACK_ENABLE_DOWNLOAD_PROMPT": "0", "YARN_IGNORE_PATH": "true"},
     )
 
 
@@ -164,7 +166,9 @@ def test_corepack_installed_correct_yarn_version_fail(
         _verify_corepack_yarn_version(expected_yarn_version, rooted_tmp_path)
 
     mock_run_yarn_cmd.assert_called_once_with(
-        ["--version"], rooted_tmp_path, env={"COREPACK_ENABLE_DOWNLOAD_PROMPT": "0"}
+        ["--version"],
+        rooted_tmp_path,
+        env={"COREPACK_ENABLE_DOWNLOAD_PROMPT": "0", "YARN_IGNORE_PATH": "true"},
     )
 
 


### PR DESCRIPTION
Unless yarnPath is ignored, it is possible to execute an arbitrary binary when we check that the corepack downloaded yarn version is as expected.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
