### PR TITLE
chore: Report correct version tag by configuring setuptools_scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,8 @@ packages = ["hermeto"]
 
 [tool.setuptools_scm]
 fallback_version = "0.0.0+dev.fallback"
+version_scheme = "only-version"
+local_scheme = "no-local-version"
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
The weird version format was caused by missing version_scheme and local_scheme in [tool.setuptools_scm].

Closes: https://github.com/hermetoproject/hermeto/issues/822

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
