### PR TITLE
pip: Add a flag to ignore Rust dependencies

### DIFF
--- a/hermeto/core/config.py
+++ b/hermeto/core/config.py
@@ -26,7 +26,10 @@ class Config(BaseModel, extra="forbid"):
     requests_timeout: int = 300
     concurrency_limit: int = 5
 
+    # The flags below are for legacy use-cases compatibility only, must not be
+    # relied upon and will be eventually removed.
     allow_yarnberry_processing: bool = True
+    ignore_pip_dependencies_crates: bool = False
 
     @model_validator(mode="before")
     @classmethod

--- a/hermeto/core/package_managers/pip.py
+++ b/hermeto/core/package_managers/pip.py
@@ -2192,7 +2192,7 @@ def _resolve_pip(
     )
 
     # No need to search for Rust code when a user requested just binaries.
-    if allow_binary:
+    if allow_binary or get_config().ignore_pip_dependencies_crates:
         packages_containing_rust_code = []
     else:
         packages_containing_rust_code = _filter_packages_with_rust_code(


### PR DESCRIPTION
Some users reported a desire to NOT process Rust dependencies automatically. This change introduces a flag to let them do that.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
