### PR TITLE
[gomod] Apply the permissive setting on go vendor directory integrity checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ Hermeto can be run in two modes using the global CLI option `--mode`.
 The default mode is `strict`. In this mode, _some_ input requirements that are not met are treated
 as errors. On the other hand, the `permissive` mode treats them as warnings. This means that Hermeto
 will proceed and generate an SBOM, but it may not be complete or accurate.
+The permissive mode can currently suppress the following:
+* go `vendor` directory inconsistencies (See `docs/gomod.md` on vendoring information)
 
 ### Available configuration parameters
 

--- a/hermeto/core/models/input.py
+++ b/hermeto/core/models/input.py
@@ -67,6 +67,9 @@ class Mode(str, enum.Enum):
     STRICT = "strict"
     PERMISSIVE = "permissive"
 
+    def __str__(self) -> str:
+        return self.value
+
 
 class _PackageInputBase(pydantic.BaseModel, extra="forbid"):
     """Common input attributes accepted for all package types."""

--- a/hermeto/interface/logging.py
+++ b/hermeto/interface/logging.py
@@ -1,6 +1,8 @@
 import enum
 import logging
-from typing import Iterable
+from typing import Any, Iterable
+
+from hermeto.core.models.input import Mode
 
 LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
 
@@ -13,6 +15,31 @@ class LogLevel(str, enum.Enum):
     WARNING = "WARNING"
     ERROR = "ERROR"
     CRITICAL = "CRITICAL"
+
+
+class EnforcingModeLoggerAdapter(logging.LoggerAdapter):
+    """
+    Enforcing mode aware logger adapter.
+
+    This adapter is to be used as the logger wrapper providing functionality to
+    decide whether to log a warning or an error based on context and on the CLI mode setting.
+    """
+
+    def error_or_warn(self, msg: str, *args: Any, enforcing_mode: Mode, **kwargs: Any) -> None:
+        """
+        Log an error or a warning based on the CLI enforcing mode setting.
+
+        We don't want all errors converted to warnings, most of them will always
+        be fatal, so this warning/error wrapper is just an addition to the standard set of logger
+        methods for cases where context is the decisive factor.
+        """
+        # NOTE: We should probably drop the enforcing_mode argument in favour of e.g. a Singleton
+        # settings instance.
+        msg = f"[mode:{str(enforcing_mode).upper()}] {msg}"
+        if enforcing_mode == Mode.PERMISSIVE:
+            self.warning(msg, *args, **kwargs)
+        else:
+            self.error(msg, *args, **kwargs)
 
 
 def setup_logging(level: LogLevel, additional_modules: Iterable[str] = ()) -> None:

--- a/tests/integration/test_gomod.py
+++ b/tests/integration/test_gomod.py
@@ -61,6 +61,19 @@ log = logging.getLogger(__name__)
             ),
             id="gomod_wrong_vendor_fails_vendor_check",
         ),
+        pytest.param(
+            utils.TestParameters(
+                branch="gomod/wrong-vendor-fails-vendor-check",
+                global_flags=["--mode=permissive"],
+                packages=({"path": ".", "type": "gomod"},),
+                check_output=False,
+                check_deps_checksums=False,
+                check_vendor_checksums=False,
+                expected_exit_code=0,
+                expected_output="All dependencies fetched successfully",
+            ),
+            id="gomod_wrong_vendor_passes_vendor_check_in_permissive_mode",
+        ),
         # Test case checks if request will fail when source provided empty vendor.
         pytest.param(
             utils.TestParameters(
@@ -76,6 +89,19 @@ log = logging.getLogger(__name__)
                 ),
             ),
             id="gomod_empty_vendor_fails_vendor_check",
+        ),
+        pytest.param(
+            utils.TestParameters(
+                branch="gomod/empty-vendor-fails-vendor-check",
+                global_flags=["--mode=permissive"],
+                packages=({"path": ".", "type": "gomod"},),
+                check_output=False,
+                check_deps_checksums=False,
+                check_vendor_checksums=False,
+                expected_exit_code=0,
+                expected_output="All dependencies fetched successfully",
+            ),
+            id="gomod_empty_vendor_passes_vendor_check_in_permissive_mode",
         ),
         # Test case checks if package can be replaced with local dependency
         pytest.param(

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -73,6 +73,7 @@ class TestParameters:
     check_vendor_checksums: bool = True
     expected_exit_code: int = 0
     expected_output: str = ""
+    global_flags: List[str] = field(default_factory=list)
     flags: List[str] = field(default_factory=list)
 
 
@@ -376,8 +377,8 @@ def fetch_deps_and_check_output(
         "--output",
         str(output_dir),
     ]
-    if test_params.flags:
-        cmd += test_params.flags
+    cmd = test_params.global_flags + cmd
+    cmd += test_params.flags
 
     cmd.append(json.dumps(test_params.packages))
 

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -1541,12 +1541,9 @@ def test_parse_vendor_unexpected_format(
 @pytest.mark.parametrize(
     "vendor_before, vendor_changes, expected_change",
     [
-        # no vendor/ dirs
-        ({}, {}, None),
-        # no changes
-        ({"vendor": {"modules.txt": "foo v1.0.0\n"}}, {}, None),
-        # vendor/modules.txt was added
-        (
+        pytest.param({}, {}, None, id="no_vendoring"),
+        pytest.param({"vendor": {"modules.txt": "foo v1.0.0\n"}}, {}, None, id="no_changes"),
+        pytest.param(
             {},
             {"vendor": {"modules.txt": "foo v1.0.0\n"}},
             textwrap.dedent(
@@ -1557,9 +1554,9 @@ def test_parse_vendor_unexpected_format(
                 +foo v1.0.0
                 """
             ),
+            id="modules_txt_added",
         ),
-        # vendor/modules.txt changed
-        (
+        pytest.param(
             {"vendor": {"modules.txt": "foo v1.0.0\n"}},
             {"vendor": {"modules.txt": "foo v2.0.0\n"}},
             textwrap.dedent(
@@ -1571,9 +1568,9 @@ def test_parse_vendor_unexpected_format(
                 +foo v2.0.0
                 """
             ),
+            id="modules_txt_changes",
         ),
-        # vendor/some_file was added
-        (
+        pytest.param(
             {},
             {"vendor": {"some_file": "foo"}},
             textwrap.dedent(
@@ -1581,9 +1578,9 @@ def test_parse_vendor_unexpected_format(
                 A\t{subpath}vendor/some_file
                 """
             ),
+            id="a_file_was_added",
         ),
-        # multiple additions and modifications
-        (
+        pytest.param(
             {"vendor": {"some_file": "foo"}},
             {"vendor": {"some_file": "bar", "other_file": "baz"}},
             textwrap.dedent(
@@ -1592,11 +1589,12 @@ def test_parse_vendor_unexpected_format(
                 M\t{subpath}vendor/some_file
                 """
             ),
+            id="multiple_changes",
         ),
         # vendor/ was added but only contains empty dirs => will be ignored
-        ({}, {"vendor": {"empty_dir": {}}}, None),
+        pytest.param({}, {"vendor": {"empty_dir": {}}}, None, id="vendor_empty_dirs"),
         # change will be tracked even if vendor/ is .gitignore'd
-        (
+        pytest.param(
             {".gitignore": "vendor/"},
             {"vendor": {"some_file": "foo"}},
             textwrap.dedent(
@@ -1604,6 +1602,7 @@ def test_parse_vendor_unexpected_format(
                 A\t{subpath}vendor/some_file
                 """
             ),
+            id="file_added_in_gitignored_vendor_dir",
         ),
     ],
 )


### PR DESCRIPTION
Resolves: https://github.com/hermetoproject/hermeto/issues/933

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
