### PR TITLE
core: scm: Specify the keyword 'count' in our re.sub call

### DIFF
--- a/hermeto/core/scm.py
+++ b/hermeto/core/scm.py
@@ -83,7 +83,7 @@ def _canonicalize_origin_url(url: str) -> str:
         parts = url.split("@", 1)
         # replace the ':' in the host:path part with a '/'
         # and strip leading '/' from the path, if any
-        parts[-1] = re.sub(r":/*", "/", parts[-1], 1)
+        parts[-1] = re.sub(r":/*", "/", parts[-1], count=1)
         return "ssh://" + "@".join(parts)
     else:
         raise UnsupportedFeature(


### PR DESCRIPTION
This addresses the following pytest warning under Python 3.13 I noticed by accident:

    DeprecationWarning: 'count' is passed as positional argument
    parts[-1] = re.sub(r":/*", "/", parts[-1], 1)

This warning is a result of change [1] in cpython, presumably to counter common passing argument mistake by misplacing flags to various re calls [2]. Based on [1] several other keyword arguments are to be converted to keyword-only arguments in the future anyway, so we might need more changes just like this one in the future.

[1] https://github.com/python/cpython/commit/882cb79afa2cb11b180ef699fd5cf038e72f6c85
[2] https://github.com/python/cpython/issues/99918#issuecomment-1333377637

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
