### PR TITLE
Konflux onboarding: add Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "packageRules": [
+    {
+      "groupName": "Tekton CI",
+      "matchFileNames": [
+        ".tekton/**"
+      ],
+      "schedule": "weekly"
+    },
+    {
+      "groupName": "Github Actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "schedule": "weekly"
+    },
+    {
+      "groupName": "Dockerfile",
+      "matchManagers": [
+        "dockerfile"
+      ],
+      "schedule": "monthly"
+    },
+    {
+      "groupName": "Pip Minor/Patch",
+      "matchManagers": [
+        "pip_requirements"
+      ],
+      "matchUpdateTypes": [
+        "minor", "patch"
+      ],
+      "schedule": "monthly"
+    },
+    {
+      "groupName": "Pip Major",
+      "matchManagers": [
+        "pip_requirements"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "schedule": "monthly"
+    }
+  ]
+}


### PR DESCRIPTION
In order to avoid getting a flood of PRs by Renovate, we need to configure package group for the updates. The initial `renovate.json` file introduced here tries to mostly copy what we have configured for Dependabot. The only configuration I have not copied yet is the supression of `pydating-core` updates (see this commit), since I want to test how Renovate deals with this particular dependency.

In any case, this change assumes that we want all the updates to be handled by Renovate. Alternatively, we can still keep all the updates by Dependabot, and only rely on Renovate to update the Tekton CI definitions.

For more info on Renovate configuration, check the [official docs](https://docs.renovatebot.com/configuration-options/#packagerules).

This should only be merged after #930. 

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
