### PR TITLE
tests: integration: Switch our RPM e2e test to UBI 9

### DIFF
--- a/tests/integration/test_data/rpm_e2e/bom.json
+++ b/tests/integration/test_data/rpm_e2e/bom.json
@@ -9,45 +9,9 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:rpm/fedora/gpm-libs@1.20.7-44.fc39?arch=x86_64&checksum=sha256:f5c8f20f0f9468da8cdf140d7df30ed117a43b73eee816888e2624b0fcd048ca&repository_id=releases",
+      "purl": "pkg:rpm/redhat/gpm-libs@1.20.7-29.el9?arch=x86_64&checksum=sha256:fc3455407e79462bfd944eea5d11d19186ad741be5a83e7ac1720fc181e3cc90&repository_id=ubi-9-appstream-rpms",
       "type": "library",
       "version": "1.20.7"
-    },
-    {
-      "name": "gpm",
-      "properties": [
-        {
-          "name": "hermeto:found_by",
-          "value": "hermeto"
-        }
-      ],
-      "purl": "pkg:rpm/fedora/gpm@1.20.7-44.fc39?arch=src&checksum=sha256:2eb2412dde91b1130433c90ad53b889cb1e0fb0df324e015f29e76d7235ac438&repository_id=releases",
-      "type": "library",
-      "version": "1.20.7"
-    },
-    {
-      "name": "libsodium",
-      "properties": [
-        {
-          "name": "hermeto:found_by",
-          "value": "hermeto"
-        }
-      ],
-      "purl": "pkg:rpm/fedora/libsodium@1.0.18-14.fc39?arch=src&checksum=sha256:d20e5f6e358aa0c07260872ffb00d502f77778ae7496a836da0a65a6ce1cd709&repository_id=releases",
-      "type": "library",
-      "version": "1.0.18"
-    },
-    {
-      "name": "libsodium",
-      "properties": [
-        {
-          "name": "hermeto:found_by",
-          "value": "hermeto"
-        }
-      ],
-      "purl": "pkg:rpm/fedora/libsodium@1.0.18-14.fc39?arch=x86_64&checksum=sha256:e38200a7b1012935dc83e8039c71c0fd2f84a4463ca086cb42f60f488cdad8e7&repository_id=releases",
-      "type": "library",
-      "version": "1.0.18"
     },
     {
       "name": "vim-common",
@@ -57,21 +21,9 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:rpm/fedora/vim-common@9.0.1927-1.fc39?arch=x86_64&checksum=sha256:4cb8015a858439f519d5d2aa82fd853f3d1dd7f927a33d25d9598e54ee6201bc&epoch=2&repository_id=releases",
+      "purl": "pkg:rpm/redhat/vim-common@8.2.2637-22.el9_6?arch=x86_64&checksum=sha256:2204d3adc043d761081a2d39c75004ec4880dfc29de755c58d5fa4e15c81d3c3&epoch=2&repository_id=ubi-9-appstream-rpms",
       "type": "library",
-      "version": "9.0.1927"
-    },
-    {
-      "name": "vim-data",
-      "properties": [
-        {
-          "name": "hermeto:found_by",
-          "value": "hermeto"
-        }
-      ],
-      "purl": "pkg:rpm/fedora/vim-data@9.0.1927-1.fc39?arch=noarch&checksum=sha256:35d7b9542e46eca30d951960effe9a8e738543a839f0dbb3cf723da0958c355b&epoch=2&repository_id=releases",
-      "type": "library",
-      "version": "9.0.1927"
+      "version": "8.2.2637"
     },
     {
       "name": "vim-enhanced",
@@ -81,9 +33,9 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:rpm/fedora/vim-enhanced@9.0.1927-1.fc39?arch=x86_64&checksum=sha256:615d46a08fbbd0eca6a6e8d2d23a6b5847db11c886e0dc979ffebab66236532d&epoch=2&repository_id=releases",
+      "purl": "pkg:rpm/redhat/vim-enhanced@8.2.2637-22.el9_6?arch=x86_64&checksum=sha256:aed2e552a0721e5d260362bc4013691a4cd722664e6cb6c93d70ddaf1548fd57&epoch=2&repository_id=ubi-9-appstream-rpms",
       "type": "library",
-      "version": "9.0.1927"
+      "version": "8.2.2637"
     },
     {
       "name": "vim-filesystem",
@@ -93,81 +45,9 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:rpm/fedora/vim-filesystem@9.0.1927-1.fc39?arch=noarch&checksum=sha256:f645ed8cda2fa07ba991320a684d9b71de75ff25220468b08fb36f6a5a231178&epoch=2&repository_id=releases",
+      "purl": "pkg:rpm/redhat/vim-filesystem@8.2.2637-22.el9_6?arch=noarch&checksum=sha256:744aceed764a5a4f5e4f12a70237ff74cb93c375aabffe4dc245e474628775c2&epoch=2&repository_id=ubi-9-baseos-rpms",
       "type": "library",
-      "version": "9.0.1927"
-    },
-    {
-      "name": "vim-minimal",
-      "properties": [
-        {
-          "name": "hermeto:found_by",
-          "value": "hermeto"
-        }
-      ],
-      "purl": "pkg:rpm/fedora/vim-minimal@9.0.1927-1.fc39?arch=x86_64&checksum=sha256:37a216f1af9f2eb961a9fa6674861146d11ca56fc9c576fa17a8cb7d806aa0af&epoch=2&repository_id=releases",
-      "type": "library",
-      "version": "9.0.1927"
-    },
-    {
-      "name": "vim",
-      "properties": [
-        {
-          "name": "hermeto:found_by",
-          "value": "hermeto"
-        }
-      ],
-      "purl": "pkg:rpm/fedora/vim@9.0.1927-1.fc39?arch=src&checksum=sha256:dae76267f265093d0e1b178c05af197bc21b994a264c9c4e7701cce095b62f03&epoch=2&repository_id=releases",
-      "type": "library",
-      "version": "9.0.1927"
-    },
-    {
-      "name": "which",
-      "properties": [
-        {
-          "name": "hermeto:found_by",
-          "value": "hermeto"
-        }
-      ],
-      "purl": "pkg:rpm/fedora/which@2.21-40.fc39?arch=src&checksum=sha256:791428d30c136a2ff8e781b9c32cbd3d506699f1369ae2a589c02fceb72d4533&repository_id=releases",
-      "type": "library",
-      "version": "2.21"
-    },
-    {
-      "name": "which",
-      "properties": [
-        {
-          "name": "hermeto:found_by",
-          "value": "hermeto"
-        }
-      ],
-      "purl": "pkg:rpm/fedora/which@2.21-40.fc39?arch=x86_64&checksum=sha256:ec1d8a1c0d88883a03e96ba88a6278899bd559fb37833cb2383ffdd6a38c22ae&repository_id=releases",
-      "type": "library",
-      "version": "2.21"
-    },
-    {
-      "name": "xxd",
-      "properties": [
-        {
-          "name": "hermeto:found_by",
-          "value": "hermeto"
-        }
-      ],
-      "purl": "pkg:rpm/fedora/xxd@9.0.1927-1.fc39?arch=x86_64&checksum=sha256:e770b0a0e5e51225a76069d2210551a90f3140913f90f33759d002055179ecc7&epoch=2&repository_id=releases",
-      "type": "library",
-      "version": "9.0.1927"
-    },
-    {
-      "name": "libftl",
-      "properties": [
-        {
-          "name": "hermeto:found_by",
-          "value": "hermeto"
-        }
-      ],
-      "purl": "pkg:rpm/rpm_fusion/libftl@0.9.14-12.fc39?arch=x86_64&checksum=sha256:6b0d8d3329150151fb8ea1eba7a4b464f112326777bee7a2e202753adc767281&repository_id=rpmfusion-free",
-      "type": "library",
-      "version": "0.9.14"
+      "version": "8.2.2637"
     }
   ],
   "metadata": {

--- a/tests/integration/test_data/rpm_e2e/container/Containerfile
+++ b/tests/integration/test_data/rpm_e2e/container/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:39
+FROM registry.access.redhat.com/ubi9:9.6-1752625787
 
 RUN dnf -y install \
 	vim

--- a/tests/integration/test_data/rpm_e2e/fetch_deps_sha256sums.json
+++ b/tests/integration/test_data/rpm_e2e/fetch_deps_sha256sums.json
@@ -1,16 +1,6 @@
 {
-  "rpm/x86_64/releases/gpm-1.20.7-44.fc39.src.rpm": "sha256:2eb2412dde91b1130433c90ad53b889cb1e0fb0df324e015f29e76d7235ac438",
-  "rpm/x86_64/releases/gpm-libs-1.20.7-44.fc39.x86_64.rpm": "sha256:f5c8f20f0f9468da8cdf140d7df30ed117a43b73eee816888e2624b0fcd048ca",
-  "rpm/x86_64/releases/libsodium-1.0.18-14.fc39.src.rpm": "sha256:d20e5f6e358aa0c07260872ffb00d502f77778ae7496a836da0a65a6ce1cd709",
-  "rpm/x86_64/releases/libsodium-1.0.18-14.fc39.x86_64.rpm": "sha256:e38200a7b1012935dc83e8039c71c0fd2f84a4463ca086cb42f60f488cdad8e7",
-  "rpm/x86_64/releases/vim-9.0.1927-1.fc39.src.rpm": "sha256:dae76267f265093d0e1b178c05af197bc21b994a264c9c4e7701cce095b62f03",
-  "rpm/x86_64/releases/vim-common-9.0.1927-1.fc39.x86_64.rpm": "sha256:4cb8015a858439f519d5d2aa82fd853f3d1dd7f927a33d25d9598e54ee6201bc",
-  "rpm/x86_64/releases/vim-data-9.0.1927-1.fc39.noarch.rpm": "sha256:35d7b9542e46eca30d951960effe9a8e738543a839f0dbb3cf723da0958c355b",
-  "rpm/x86_64/releases/vim-enhanced-9.0.1927-1.fc39.x86_64.rpm": "sha256:615d46a08fbbd0eca6a6e8d2d23a6b5847db11c886e0dc979ffebab66236532d",
-  "rpm/x86_64/releases/vim-filesystem-9.0.1927-1.fc39.noarch.rpm": "sha256:f645ed8cda2fa07ba991320a684d9b71de75ff25220468b08fb36f6a5a231178",
-  "rpm/x86_64/releases/vim-minimal-9.0.1927-1.fc39.x86_64.rpm": "sha256:37a216f1af9f2eb961a9fa6674861146d11ca56fc9c576fa17a8cb7d806aa0af",
-  "rpm/x86_64/releases/which-2.21-40.fc39.src.rpm": "sha256:791428d30c136a2ff8e781b9c32cbd3d506699f1369ae2a589c02fceb72d4533",
-  "rpm/x86_64/releases/which-2.21-40.fc39.x86_64.rpm": "sha256:ec1d8a1c0d88883a03e96ba88a6278899bd559fb37833cb2383ffdd6a38c22ae",
-  "rpm/x86_64/releases/xxd-9.0.1927-1.fc39.x86_64.rpm": "sha256:e770b0a0e5e51225a76069d2210551a90f3140913f90f33759d002055179ecc7",
-  "rpm/x86_64/rpmfusion-free/libftl-0.9.14-12.fc39.x86_64.rpm": "sha256:6b0d8d3329150151fb8ea1eba7a4b464f112326777bee7a2e202753adc767281"
+  "rpm/x86_64/ubi-9-appstream-rpms/gpm-libs-1.20.7-29.el9.x86_64.rpm": "sha256:fc3455407e79462bfd944eea5d11d19186ad741be5a83e7ac1720fc181e3cc90",
+  "rpm/x86_64/ubi-9-appstream-rpms/vim-common-8.2.2637-22.el9_6.x86_64.rpm": "sha256:2204d3adc043d761081a2d39c75004ec4880dfc29de755c58d5fa4e15c81d3c3",
+  "rpm/x86_64/ubi-9-appstream-rpms/vim-enhanced-8.2.2637-22.el9_6.x86_64.rpm": "sha256:aed2e552a0721e5d260362bc4013691a4cd722664e6cb6c93d70ddaf1548fd57",
+  "rpm/x86_64/ubi-9-baseos-rpms/vim-filesystem-8.2.2637-22.el9_6.noarch.rpm": "sha256:744aceed764a5a4f5e4f12a70237ff74cb93c375aabffe4dc245e474628775c2"
 }

--- a/tests/integration/test_rpm.py
+++ b/tests/integration/test_rpm.py
@@ -256,7 +256,7 @@ def test_repo_files(
                 expected_output="All dependencies fetched successfully",
             ),
             ["vim", "--version"],
-            ["VIM - Vi IMproved 9.0"],
+            ["VIM - Vi IMproved 8.2"],
             id="rpm_e2e",
         ),
         # Test case that checks fetching RPM and module metadata files, generating repos and repofiles,


### PR DESCRIPTION
Our current Fedora 39-based on is failing because 39 has been EOL'd for a while and so under Fedora's policy has moved to archive [1], [2].

[1] https://dl.fedoraproject.org/pub/fedora/linux/releases/39/
[2] https://dl.fedoraproject.org/pub/archive/fedora/linux/releases/39/

This is inevitably going to happen with future EOL'd releases again, so let's switch to UBI which doesn't have this policy and so the URLs should remain stable for longer.

**Depends on: https://github.com/hermetoproject/integration-tests/pull/13**
**Blocks: https://github.com/hermetoproject/hermeto/pull/1028**