### PR TITLE
noxfile: Enable pytest's coverage conditionally

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -99,7 +99,12 @@ def unit_tests(session: Session) -> None:
     session.install(".")
     # disable color output in GitHub Actions
     env = {"TERM": "dumb"} if os.getenv("CI") == "true" else None
-    cmd = "pytest --log-level=DEBUG -W ignore::DeprecationWarning --cov=hermeto --cov-config=pyproject.toml --cov-report=term --cov-report=html --cov-report=xml --no-cov-on-fail tests/unit"
+    cmd = "pytest --log-level=DEBUG -W ignore::DeprecationWarning tests/unit"
+
+    if not session.posargs:
+        # enable coverage when no pytest positional arguments are passed through
+        cmd += " --cov=hermeto --cov-config=pyproject.toml --cov-report=term --cov-report=html --cov-report=xml --no-cov-on-fail"
+
     session.run(*cmd.split(), *session.posargs, env=env)
 
 


### PR DESCRIPTION
If one passes additional positional arguments via --, e.g.
```
    $ nox -s python-3.12 -- tests/unit/package_manager/foo OR
    $ nox -s python-3.13 -- -k 'filter'
```
pytest's coverage module is all confused because apparently pytest configures it using the number of all tests collected rather than having it based on the filtered set (which would probably cause other issues) and so the coverage report fails with a returncode of 1. In manual mode you can ignore this, but in automated test runs, e.g. with git bisect this would always return failure and hence a "bad commit".

Fix this by only enabling coverage when no positional arguments were detected on the CLI.