### PR TITLE
pip: re-introduce heuristic for Cargo.toml detection

### DIFF
--- a/hermeto/core/package_managers/pip/rust.py
+++ b/hermeto/core/package_managers/pip/rust.py
@@ -87,8 +87,13 @@ def filter_packages_with_rust_code(packages: list[dict[str, Any]]) -> list[Cargo
         if not _depends_on_rust(source_dir):
             shutil.rmtree(extract_dir, ignore_errors=True)
             continue
-
-        rust_root_dir = cargo_files[0].parent
+        # find the top-most Cargo.toml in the package - that's not necessarily the most accurate
+        # solution, but this heuristic has proven to work on the most popular python packages
+        # that have rust dependencies; if this stops working, then we would probably need to check
+        # pyproject toml config section for maturin or setuptools-rust...
+        # More info on this issue in the design doc
+        # https://github.com/hermetoproject/hermeto/blob/e5fa5c0fcd0dff62cf02be5b0d219e04c1ea440c/docs/design/cargo-support.md#L806
+        rust_root_dir = min(cargo_files, key=lambda x: len(x.parts)).parent
         packages_containing_rust_code.append(
             CargoPackageInput(
                 type="cargo",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,7 +19,10 @@ log = logging.getLogger(__name__)
 
 @pytest.fixture(scope="session")
 def test_repo_dir(tmp_path_factory: pytest.FixtureRequest) -> Path:
-    test_repo_url = "https://github.com/hermetoproject/integration-tests.git"
+    test_repo_url = os.environ.get(
+        "HERMETO_TEST_INTEGRATION_TESTS_REPO",
+        "https://github.com/hermetoproject/integration-tests.git",
+    )
     # https://pytest.org/en/latest/reference/reference.html#tmp-path-factory-factory-api
     repo_dir = tmp_path_factory.mktemp("integration-tests", False)  # type: ignore
     Repo.clone_from(url=test_repo_url, to_path=repo_dir, depth=1, no_single_branch=True)

--- a/tests/integration/test_pip.py
+++ b/tests/integration/test_pip.py
@@ -153,6 +153,17 @@ log = logging.getLogger(__name__)
             ),
             id="pip_rust_extension_lock_and_config_mismatch_strict",
         ),
+        pytest.param(
+            utils.TestParameters(
+                branch="pip/rust_dependency_unusual_cargo_toml_location",
+                packages=({"path": ".", "type": "pip"},),
+                expected_exit_code=0,
+                check_output=False,
+                check_deps_checksums=False,
+                expected_output="All dependencies fetched successfully",
+            ),
+            id="pip_rust_dependency_unusual_cargo_toml_location",
+        ),
     ],
 )
 def test_pip_packages(


### PR DESCRIPTION
Looks like d78fb42 fix accidentaly removed the heuristic for selecting the proper Cargo.toml when multiple files are present.

This commit simply reintroduces the same heuristic.

Closes #1039 .

Depends on https://github.com/hermetoproject/integration-tests/pull/25

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
