### PR TITLE
pip: chore: Move Cargo root resolution into a separate function

### DIFF
--- a/hermeto/core/package_managers/pip/rust.py
+++ b/hermeto/core/package_managers/pip/rust.py
@@ -4,7 +4,7 @@ import logging
 import shutil
 from pathlib import Path
 from textwrap import dedent
-from typing import Any
+from typing import Any, Iterable
 
 from pybuild_deps import parsers
 
@@ -50,6 +50,16 @@ def _depends_on_rust(extracted_dir: Path) -> bool:
     return False
 
 
+def _get_rust_root_dir(cargo_files: Iterable[Path]) -> Path:
+    # find the top-most Cargo.toml in the package - that's not necessarily the most accurate
+    # solution, but this heuristic has proven to work on the most popular python packages
+    # that have rust dependencies; if this stops working, then we would probably need to check
+    # pyproject toml config section for maturin or setuptools-rust...
+    # More info on this issue in the design doc
+    # https://github.com/hermetoproject/hermeto/blob/e5fa5c0fcd0dff62cf02be5b0d219e04c1ea440c/docs/design/cargo-support.md#L806
+    return min(cargo_files, key=lambda x: len(x.parts)).parent
+
+
 def filter_packages_with_rust_code(packages: list[dict[str, Any]]) -> list[CargoPackageInput]:
     """Filter packages that contain Rust code from a list of pip packages."""
     packages_containing_rust_code = []
@@ -87,13 +97,7 @@ def filter_packages_with_rust_code(packages: list[dict[str, Any]]) -> list[Cargo
         if not _depends_on_rust(source_dir):
             shutil.rmtree(extract_dir, ignore_errors=True)
             continue
-        # find the top-most Cargo.toml in the package - that's not necessarily the most accurate
-        # solution, but this heuristic has proven to work on the most popular python packages
-        # that have rust dependencies; if this stops working, then we would probably need to check
-        # pyproject toml config section for maturin or setuptools-rust...
-        # More info on this issue in the design doc
-        # https://github.com/hermetoproject/hermeto/blob/e5fa5c0fcd0dff62cf02be5b0d219e04c1ea440c/docs/design/cargo-support.md#L806
-        rust_root_dir = min(cargo_files, key=lambda x: len(x.parts)).parent
+        rust_root_dir = _get_rust_root_dir(cargo_files)
         packages_containing_rust_code.append(
             CargoPackageInput(
                 type="cargo",

--- a/tests/unit/package_managers/pip/test_rust.py
+++ b/tests/unit/package_managers/pip/test_rust.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pytest
+
+from hermeto.core.package_managers.pip.rust import _get_rust_root_dir
+
+
+@pytest.mark.parametrize(
+    "cargo_files,expected_rust_root_dir",
+    [
+        pytest.param(
+            (Path("/tmp/foo/Cargo.toml"), Path("/tmp/bar/baz/Cargo.toml")),
+            Path("/tmp/foo"),
+            id="simple_ordering",
+        ),
+        pytest.param(
+            (Path("/tmp/bar/baz/Cargo.toml"), Path("/tmp/foo/Cargo.toml")),
+            Path("/tmp/foo"),
+            id="reversed_simple_ordering",
+        ),
+        pytest.param(
+            (
+                Path("/tmp/bar/baz/Cargo.toml"),
+                Path("/tmp/foo/Cargo.toml"),
+                Path("/tmp/foo/quux/Cargo.toml"),
+            ),
+            Path("/tmp/foo"),
+            id="tricky_ordering",
+        ),
+    ],
+)
+def test_the_shortest_path_in_cargo_package_is_inferred_as_root(
+    cargo_files: tuple, expected_rust_root_dir: Path
+) -> None:
+
+    inferred_rust_root_dir = _get_rust_root_dir(cargo_files)
+
+    assert inferred_rust_root_dir == expected_rust_root_dir


### PR DESCRIPTION
Heuristic for resolving Cargo root directory was reintroduced recently (https://github.com/hermetoproject/hermeto/pull/1040). Unfortunately the problem that it was solving turned out to be system-dependent and thus not directly testable with an integration test. Since this heuristic has once been replaced during refactoring there must be some test that guards against future regressions. This change pulls heuristic into a separate function and covers that function with unit tests to warn future maintainers about possible regressions.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
