### PR TITLE
Add requirements-build.txt file

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,3 @@
+setuptools==80.9.0
+setuptools-scm==8.2.0
+


### PR DESCRIPTION
The setuptools-scm library is needed as a dependency when building the project. The lack of this dependency will make the build fail in a hermetic environment.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

