### PR TITLE
Toil(docs): fix broken `pre` links in Pip.md

### DIFF
--- a/docs/bundler.md
+++ b/docs/bundler.md
@@ -84,7 +84,8 @@ lockfile has not been updated, running Bundler commands will be blocked. More
 importantly though, this makes Bundler comply with network isolated builds.
 However, this setting has a user-side implication regarding their build recipes,
 e.g. Dockerfiles[^1] and you may want to consider enforcing the installation
-path for your app explicitly with [`BUNDLE_PATH`][]
+path for your app explicitly with
+[`BUNDLE_PATH`](https://bundler.io/v2.5/man/bundle-config.1.html#LIST-OF-AVAILABLE-KEYS)
 
 ### BUNDLE_NO_PRUNE
 
@@ -190,7 +191,6 @@ Note that the deployment mode doesn't play nicely with other installation flags
 and so trying to use `--local` with your `bundle install` command in your
 Dockerfile won't take effect, consider `BUNDLE_PATH` instead.
 
-[`BUNDLE_PATH`]: https://bundler.io/v2.5/man/bundle-config.1.html#LIST-OF-AVAILABLE-KEYS
 [Bundler]: https://bundler.io
 [configuration options]: https://bundler.io/v2.5/man/bundle-config.1.html#DESCRIPTION
 [deployment mode]: https://www.bundler.cn/man/bundle-install.1.html#DEPLOYMENT-MODE

--- a/docs/gomod.md
+++ b/docs/gomod.md
@@ -223,7 +223,8 @@ suggested version as it originally did. The format of the version string in the
 `go` directive now also includes the micro release and if you don't include the
 micro release in your `go.qmod` file yourself (i.e. you only specify the
 language release) Go will try to correct it automatically inside the file. Last
-but not least, Go 1.21 also introduced a new keyword [`toolchain`][] to the
+but not least, Go 1.21 also introduced a new keyword
+[`toolchain`](https://go.dev/ref/mod#go-mod-file-toolchain) to the
 `go.mod` file. What this all means in practice for end users is that you may not
 be able to process your `go.mod` file with an older version of Go (and hence
 older hermeto) as you could in the past for various reasons. Many projects bump
@@ -346,7 +347,6 @@ podman run --rm -ti fzf
   packages. This can cause Hermeto to miss the transitive package dependencies
   of packages from checksum-less modules.
 
-[`toolchain`]: https://go.dev/ref/mod#go-mod-file-toolchain
 [cgo]: https://pkg.go.dev/cmd/cgo
 [fzf]: https://github.com/junegunn/fzf
 [Go 1.21]: https://tip.golang.org/doc/go1.21

--- a/docs/pip.md
+++ b/docs/pip.md
@@ -251,7 +251,7 @@ Note that if at least one dependency in your requirements file uses `--hash`,
 pip requires hashes for all dependencies. Use `pip-compile --generate-hashes` to
 generate compliant requirements files.
 
-*Hermeto does not support PEP 440 hashes in the url fragment, only --hash
+*Hermeto does not support PEP 440 hashes in the url fragment, only `--hash`
 options.*
 
 #### git urls
@@ -492,8 +492,8 @@ hermeto-output/deps/pip
 ```
 
 To make pip use the downloaded archives, use the [`--find-links`][] and
-[`--no-index`][] options. The --find-links option tells pip to look for
-dependency archives in a directory, --no-index prevents pip from preferring PyPI
+[`--no-index`][] options. The `--find-links` option tells pip to look for
+dependency archives in a directory, `--no-index` prevents pip from preferring PyPI
 over the local directory. Pip also accepts environment variables; Hermeto
 generates `PIP_FIND_LINKS` and `PIP_NO_INDEX` for you.
 See [Example: Generate environment variables](#generate-environment-variables)

--- a/docs/pip.md
+++ b/docs/pip.md
@@ -293,7 +293,7 @@ supported.
 
 #### Global
 
-##### [`--index-url`][]
+##### [`--index-url`](https://pip.pypa.io/en/stable/cli/pip_install/#install-index-url)
 
 *Supported since v0.8.0.*
 
@@ -307,14 +307,15 @@ Make Hermeto download packages from the specified Python Package Index server.
 > index server (`https://pypi.org/simple`).
 
 :warning: **Do not include credentials in the index url.** If needed, provide
-authentication via [a `.netrc` file][].
+authentication via
+[a **.netrc** file](https://pip.pypa.io/en/stable/topics/authentication/#netrc-support).
 
-##### [`--require-hashes`][]
+##### [`--require-hashes`](https://pip.pypa.io/en/stable/cli/pip_install/#install-require-hashes)
 
 Enables hash-checking mode. Typically redundant, since the presence of any
 `--hash` option enables hash-checking mode as well.
 
-##### [`--trusted-host`][]
+##### [`--trusted-host`](https://pip.pypa.io/en/stable/cli/pip/#trusted-host)
 
 Disables HTTPS validation for a host. Don't use this for production builds.
 
@@ -491,8 +492,11 @@ hermeto-output/deps/pip
 └── wheel-0.38.4.tar.gz
 ```
 
-To make pip use the downloaded archives, use the [`--find-links`][] and
-[`--no-index`][] options. The `--find-links` option tells pip to look for
+To make pip use the downloaded archives, use the
+[`--find-links`](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-f)
+and
+[`--no-index`](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-no-index)
+options. The `--find-links` option tells pip to look for
 dependency archives in a directory, `--no-index` prevents pip from preferring PyPI
 over the local directory. Pip also accepts environment variables; Hermeto
 generates `PIP_FIND_LINKS` and `PIP_NO_INDEX` for you.
@@ -598,8 +602,9 @@ document) and that you are using Hermeto as intended (for reference, see the
 *Have you read [Building from source](#building-from-source)?*
 
 Even if you have all the build dependencies available, installing from source
-can come with unforeseen complications. Pip's [`--no-binary`][] flag can help
-debug faster.
+can come with unforeseen complications. Pip's
+[`--no-binary`](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-no-binary)
+flag can help debug faster.
 
 ```shell
 # on your machine
@@ -614,7 +619,9 @@ Notably, older versions of pip and setuptools have a fair share of bugs related
 to PEP 517 handling. A good first course of action can be to upgrade pip and
 setuptools and try again.
 
-Other pip install options such as [`--use-pep517`][] may also be of interest.
+Other pip install options such as
+[`--use-pep517`](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-use-pep517)
+may also be of interest.
 
 ### Need to install newer pip
 
@@ -777,14 +784,6 @@ which should output
 Note that the repo also contains a `build.sh` script which will execute all of
 these steps for you.
 
-[`--find-links`]: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-f
-[`--no-binary`]: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-no-binary
-[`--no-index`]: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-no-index
-[`--use-pep517`]: https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-use-pep517
-[`--index-url`]: https://pip.pypa.io/en/stable/cli/pip_install/#install-index-url
-[`--require-hashes`]: https://pip.pypa.io/en/stable/cli/pip_install/#install-require-hashes
-[`--trusted-host`]: https://pip.pypa.io/en/stable/cli/pip/#trusted-host
-[a `.netrc` file]: https://pip.pypa.io/en/stable/topics/authentication/#netrc-support
 [basic pip project]: https://github.com/hermetoproject/doc-examples/tree/pip-basic
 [binary format]: https://packaging.python.org/en/latest/specifications/binary-distribution-format
 [declarative config]: https://setuptools.pypa.io/en/stable/userguide/declarative_config.html


### PR DESCRIPTION
mkdocs-material -- for reference links, renders them incorrectly/styles them weirdly:

- when the name contains *any* formatting (like [`--find-links`][] or even [**--find-links**][]), is rendered as text only (not as links)
- even after tweaking CSS, e.g. [`--find-links`][] is now not only **not** a link, but is styled as all-small-caps O_o

The only fix I could find (with Claude's help), was in-lining the links.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
