### PR TITLE
Enable platform-specific binary package filtering input

### DIFF
--- a/hermeto/core/binary_filters.py
+++ b/hermeto/core/binary_filters.py
@@ -1,0 +1,30 @@
+"""Base classes for binary package filtering."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Optional, Set
+
+from hermeto.core.models.input import BINARY_FILTER_ALL
+
+
+class BinaryPackageFilter(ABC):
+    """Abstract base class for binary package filtering."""
+
+    def _parse_filter_spec(self, spec: str) -> Optional[Set[str]]:
+        """Parse filter specification into allowed values set.
+
+        Returns None if spec is ':all:' or contains ':all:' as any item.
+        This matches pip's behavior where any occurrence of ':all:' means accept all.
+        """
+        if spec == BINARY_FILTER_ALL:
+            return None
+
+        filters = {stripped_filter for item in spec.split(",") if (stripped_filter := item.strip())}
+
+        if BINARY_FILTER_ALL in filters:
+            return None
+
+        return filters
+
+    @abstractmethod
+    def __contains__(self, item: Any) -> bool:
+        """Check if item passes the filter criteria."""

--- a/hermeto/core/models/input.py
+++ b/hermeto/core/models/input.py
@@ -163,6 +163,33 @@ def _validate_binary_filter_format(value: Any) -> str:
 BinaryFilterStr = Annotated[str, pydantic.BeforeValidator(_validate_binary_filter_format)]
 
 
+class BinaryModeOptions(pydantic.BaseModel, extra="forbid"):
+    """Base configuration for binary package handling."""
+
+    packages: BinaryFilterStr = BINARY_FILTER_ALL
+
+
+class PipBinaryFilters(BinaryModeOptions):
+    """Binary filters specific to pip packages."""
+
+    arch: BinaryFilterStr = "x86_64"
+    os: BinaryFilterStr = "linux"
+    py_version: BinaryFilterStr = BINARY_FILTER_ALL
+    py_impl: BinaryFilterStr = "cp"
+
+
+class BundlerBinaryFilters(BinaryModeOptions):
+    """Binary filters specific to bundler packages."""
+
+    platform: BinaryFilterStr = BINARY_FILTER_ALL
+
+
+class RpmBinaryFilters(pydantic.BaseModel, extra="forbid"):
+    """Binary filters specific to RPM packages."""
+
+    arch: BinaryFilterStr = BINARY_FILTER_ALL
+
+
 class BundlerPackageInput(_PackageInputBase):
     """Accepted input for a bundler package."""
 

--- a/hermeto/core/package_managers/bundler/main.py
+++ b/hermeto/core/package_managers/bundler/main.py
@@ -41,7 +41,7 @@ def fetch_bundler_source(request: Request) -> RequestOutput:
         _comps, _git_paths = _resolve_bundler_package(
             package_dir=path_within_root,
             output_dir=request.output_dir,
-            allow_binary=package.allow_binary,
+            allow_binary=package.binary is not None,
         )
         components.extend(_comps)
         git_paths.extend(_git_paths)

--- a/hermeto/core/package_managers/pip/main.py
+++ b/hermeto/core/package_managers/pip/main.py
@@ -79,7 +79,7 @@ def fetch_pip_source(request: Request) -> RequestOutput:
             request.source_dir,
             package.requirements_files,
             package.requirements_build_files,
-            package.allow_binary,
+            package.binary is not None,
         )
         purl = _generate_purl_main_package(info["package"], path_within_root)
         components.append(


### PR DESCRIPTION
This PR introduces flexible binary package filtering input parameters that allow users to specify which platform-specific packages to prefetch based on architecture, OS, Python version, and other characteristics.

This is **only** the input model implementation and does not change the current behavior. New behavior for the individual package manager backends will be added in subsequent PRs.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
