### PR TITLE
noxfile: Group linters and static analyzers to a single session - lint

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -48,13 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        nox_env:
-          - bandit
-          - black
-          - isort
-          - flake8
-          - mypy
 
     container:
       image: python:3.9-slim
@@ -71,8 +64,8 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Test '${{ matrix.nox_env }}' with nox
-      run: nox -s ${{ matrix.nox_env }}
+    - name: Run linters
+      run: nox -s lint
 
   hadolint:
     name: Hadolint


### PR DESCRIPTION
Each linter invocation installs the whole requirements-extras.txt file which results in 1.5G of disk space for just individual nox linter sessions.

    $ du -h -d1 .nox
    294M .nox/bandit
    313M .nox/mypy
    294M .nox/flake8
    294M .nox/isort
    294M .nox/black
    1.5G .nox/

I explored the possibility of not installing the full requirements-extras.txt file, but the problem is our resolved and locked requirements file would lose its meaning as we'd always be installing the latest (any) package from pypi. Additionally, the current code transcript relying on a single file is much cleaner than enumerating individual dependencies for a session, so keeping the current approach is better.

The linters take only a few seconds when reusing the virtual environment (pre-existing), so there's no loss in running all linters vs invoking individual linters on nox's CLI.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
