### PR TITLE
tests: unit: gomod: Fix repo.create_tag typo

### DIFF
--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -1924,7 +1924,7 @@ def repo_remote_with_tag(rooted_tmp_path: RootedPath) -> tuple[RootedPath, Roote
 
     git.Repo.clone_from(remote_repo_path, local_repo_path)
 
-    remote_repo.create_tag("v1.0.0", ref=initial_commit, env=GIT_PRISTINE_ENV),
+    remote_repo.create_tag("v1.0.0", ref=initial_commit, env=GIT_PRISTINE_ENV)
     remote_repo.create_tag("v2.0.0", env=GIT_PRISTINE_ENV)
 
     return remote_repo_path, local_repo_path


### PR DESCRIPTION
Fixes: b08b9667d8c5b7f1d9b3d41d77b9fb5b64876d61

