### PR TITLE
.containerignore: temporarily include labels.json

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -6,3 +6,6 @@
 !pyproject.toml
 !requirements.txt
 !MANIFEST.in
+
+# Temporary Konflux workaround
+!labels.json


### PR DESCRIPTION
The Konflux build pipeline that we currently use assumes that this file is included. Include it temporarily until a fix is implemented in the build pipeline.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
