### PR TITLE
release: use source subdir from git-clone task

### DIFF
--- a/.tekton/release.yaml
+++ b/.tekton/release.yaml
@@ -50,10 +50,10 @@ spec:
           steps:
             - name: get-semver-tag
               image: registry.access.redhat.com/ubi9/python-39
-              workingDir: $(workspaces.output.path)
+              workingDir: $(workspaces.output.path)/source
               env:
               - name: WORKSPACE_OUTPUT_PATH
-                value: $(workspaces.output.path)
+                value: $(workspaces.output.path)/source
               - name: PARAM_REVISION
                 value: $(params.revision)
               script: |
@@ -79,7 +79,7 @@ spec:
 
             - name: push-semver-tag-to-image
               image: registry.access.redhat.com/ubi9/skopeo
-              workingDir: $(workspaces.output.path)
+              workingDir: $(workspaces.output.path)/source
               env:
               - name: PARAM_REVISION
                 value: $(params.revision)


### PR DESCRIPTION
Follow-up to #1086 

https://github.com/konflux-ci/build-definitions/blob/5a0b1b741978687aab7cb99b335b8dbb63dbec82/task/git-clone/0.1/README.md?plain=1#L15

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
