### PR TITLE
fix(yarn v4): support project-root patches without workspace locators

### DIFF
--- a/hermeto/core/package_managers/yarn/resolver.py
+++ b/hermeto/core/package_managers/yarn/resolver.py
@@ -458,16 +458,17 @@ class _ComponentResolver:
     def _get_path_patch_url(self, patch_locator: PatchLocator, patch_path: Path) -> str:
         """Return a PURL-style VCS URL qualifier with subpath for a Patch."""
         if patch_locator.locator is None:
-            raise UnsupportedFeature(
-                f"{patch_locator} is missing an associated workspace locator "
-                "and {APP_NAME} expects all non-builtin yarn patches to have one"
-            )
+            # Project-root patch (v4 format) - patch path is relative to project root
+            normalized = self._project.source_dir.join_within_root(patch_path)
+            subpath_from_root = str(normalized.subpath_from_root)
+        else:
+            # Workspace-bound patch - patch path is relative to workspace
+            workspace_path = patch_locator.locator.relpath
+            normalized = self._project.source_dir.join_within_root(workspace_path, patch_path)
+            subpath_from_root = str(normalized.subpath_from_root)
 
         project_path = self._project.source_dir
-        workspace_path = patch_locator.locator.relpath
-        normalized = self._project.source_dir.join_within_root(workspace_path, patch_path)
         repo_url = get_repo_id(project_path.root).as_vcs_url_qualifier()
-        subpath_from_root = str(normalized.subpath_from_root)
 
         return f"{repo_url}#{subpath_from_root}"
 

--- a/tests/unit/package_managers/yarn/test_resolver.py
+++ b/tests/unit/package_managers/yarn/test_resolver.py
@@ -2,7 +2,7 @@ import json
 import re
 import zipfile
 from pathlib import Path
-from typing import Any, NamedTuple, Optional, Union
+from typing import Any, NamedTuple, Optional
 from unittest import mock
 from urllib.parse import quote
 
@@ -995,32 +995,77 @@ def test_get_pedigree(
     assert resolver._pedigree_mapping == expected_pedigree
 
 
-@pytest.mark.parametrize(
-    "patch",
-    [
-        pytest.param(
-            Path("foo.patch"),
-            id="path_patch_without_workspace",
-        ),
-        pytest.param(
-            "builtin<bogus/patch>",
-            id="builtin_patch_from_unknown_plugin",
-        ),
-    ],
-)
 @mock.patch("hermeto.core.package_managers.yarn.resolver.get_repo_id")
 @mock.patch("hermeto.core.package_managers.yarn.resolver.extract_yarn_version_from_env")
-def test_get_pedigree_with_unsupported_locators(
+def test_get_pedigree_with_path_patch_without_workspace_locator(
     mock_get_yarn_version: mock.Mock,
     mock_get_repo_id: mock.Mock,
-    patch: Union[Path, str],
     rooted_tmp_path: RootedPath,
 ) -> None:
+    """Path patches without workspace locators are OK (Yarn v4)."""
     mock_get_yarn_version.return_value = Version(3, 0, 0)
     mock_get_repo_id.return_value = MOCK_REPO_ID
 
-    patch_locators = [PatchLocator(NpmLocator(None, "foo", "1.0.0"), [patch], None)]
+    patch_locators = [
+        PatchLocator(
+            package=NpmLocator(None, "foo", "1.0.0"),
+            patches=[Path("foo.patch")],
+            locator=None,
+        )
+    ]
+    mock_project = mock.Mock(source_dir=rooted_tmp_path.re_root("source"))
+
+    resolver = _ComponentResolver(
+        {}, patch_locators, mock_project, rooted_tmp_path.re_root("output")
+    )
+    assert resolver is not None
+
+
+@mock.patch("hermeto.core.package_managers.yarn.resolver.get_repo_id")
+@mock.patch("hermeto.core.package_managers.yarn.resolver.extract_yarn_version_from_env")
+def test_get_pedigree_with_unsupported_builtin_patch(
+    mock_get_yarn_version: mock.Mock,
+    mock_get_repo_id: mock.Mock,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    """Builtin patches from unknown plugins are NOT OK (raise `UnsupportedFeature`)."""
+    mock_get_yarn_version.return_value = Version(3, 0, 0)
+    mock_get_repo_id.return_value = MOCK_REPO_ID
+
+    patch_locators = [
+        PatchLocator(
+            package=NpmLocator(None, "foo", "1.0.0"),
+            patches=["builtin<bogus/patch>"],
+            locator=None,
+        )
+    ]
     mock_project = mock.Mock(source_dir=rooted_tmp_path.re_root("source"))
 
     with pytest.raises(UnsupportedFeature):
         _ComponentResolver({}, patch_locators, mock_project, rooted_tmp_path.re_root("output"))
+
+
+@mock.patch("hermeto.core.package_managers.yarn.resolver.get_repo_id")
+def test_get_path_patch_url_no_workspace_locator_AND_correct_PURLs(
+    mock_get_repo_id: mock.Mock,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    """_get_path_patch_url should handle patches with `locator=None` and generates correct PURLs."""
+    mock_get_repo_id.return_value = MOCK_REPO_ID
+
+    patch_locator = PatchLocator(
+        package=NpmLocator(None, "test-package", "1.0.0"),
+        patches=[Path(".yarn/patches/test-package-npm-1.0.0-abc123.patch")],
+        locator=None,
+    )
+
+    resolver = _ComponentResolver(
+        {}, [], mock_project(rooted_tmp_path.re_root("source")), rooted_tmp_path.re_root("output")
+    )
+
+    result_purl = resolver._get_path_patch_url(
+        patch_locator, Path(".yarn/patches/test-package-npm-1.0.0-abc123.patch")
+    )
+
+    expected_purl = "git+https://github.com/org/project.git@fffffff#.yarn/patches/test-package-npm-1.0.0-abc123.patch"
+    assert result_purl == expected_purl


### PR DESCRIPTION
Closes #1085

- Adds support for Yarn v4 project-root patches which don't have workspace locators
  - Add two new test functions to verify the new functionality
  - Refactor existing test to reflect new behavior
  - Implement the core fix in `_get_path_patch_url()`

## Technical Details

### Problem

Yarn v4 introduced project-root patches (stored in `.yarn/patches/`) which don't
have workspace locators, causing Hermeto to raise `UnupportedFeature`

### Solution

Modified `_get_path_patch_url()` method in
`hermeto/core/package_managers/yarn/resolver.py` to

- Handle patches with `locator=None` (project-root patches)
- Maintain backward compatibility with workspace-bound patches
- Generate correct PURLs for both patch types

### Files Changed

- `hermeto/core/package_managers/yarn/resolver.py` - Core implementation
- `tests/unit/package_managers/yarn/test_resolver.py` - Test coverage

## Tested

- [x] New test verifies project-root patch support
- [x] New test verifies correct PURL generation
- [x] Existing tests updated to reflect new behavior
- [x] All 177 yarn tests pass across Python 3.9-3.13
- [x] mypy type checking passes
- [x] No regressions in existing functionality