### PR TITLE
pip: Prepare for binary filters support

### DIFF
--- a/hermeto/core/package_managers/pip/main.py
+++ b/hermeto/core/package_managers/pip/main.py
@@ -406,7 +406,7 @@ def _download_dependencies(
         )
         require_hashes = False
 
-    validate_requirements(requirements_file.requirements, binary_filters)
+    validate_requirements(requirements_file.requirements)
     validate_requirements_hashes(requirements_file.requirements, require_hashes)
 
     pip_deps_dir: RootedPath = output_dir.join_within_root("deps", "pip")

--- a/hermeto/core/package_managers/pip/requirements.py
+++ b/hermeto/core/package_managers/pip/requirements.py
@@ -12,6 +12,7 @@ from packaging.utils import canonicalize_name
 
 from hermeto import APP_NAME
 from hermeto.core.errors import PackageRejected, UnexpectedFormat, UnsupportedFeature
+from hermeto.core.models.input import PipBinaryFilters
 from hermeto.core.rooted_path import RootedPath
 
 log = logging.getLogger(__name__)
@@ -588,7 +589,9 @@ def process_requirements_options(options: list[str]) -> dict[str, Any]:
     return opts
 
 
-def validate_requirements(requirements: list[PipRequirement], allow_binary: bool) -> None:
+def validate_requirements(
+    requirements: list[PipRequirement], binary_filters: Optional[PipBinaryFilters] = None
+) -> None:
     """
     Validate that all requirements meet our expectations.
 
@@ -648,7 +651,7 @@ def validate_requirements(requirements: list[PipRequirement], allow_binary: bool
                     docs=PIP_EXTERNAL_DEPS_DOC,
                 )
 
-            if allow_binary:
+            if binary_filters is not None:
                 allowed_extensions = ALL_FILE_EXTENSIONS
             else:
                 allowed_extensions = SDIST_FILE_EXTENSIONS

--- a/hermeto/core/package_managers/pip/requirements.py
+++ b/hermeto/core/package_managers/pip/requirements.py
@@ -12,7 +12,6 @@ from packaging.utils import canonicalize_name
 
 from hermeto import APP_NAME
 from hermeto.core.errors import PackageRejected, UnexpectedFormat, UnsupportedFeature
-from hermeto.core.models.input import PipBinaryFilters
 from hermeto.core.rooted_path import RootedPath
 
 log = logging.getLogger(__name__)
@@ -589,9 +588,7 @@ def process_requirements_options(options: list[str]) -> dict[str, Any]:
     return opts
 
 
-def validate_requirements(
-    requirements: list[PipRequirement], binary_filters: Optional[PipBinaryFilters] = None
-) -> None:
+def validate_requirements(requirements: list[PipRequirement]) -> None:
     """
     Validate that all requirements meet our expectations.
 
@@ -651,16 +648,11 @@ def validate_requirements(
                     docs=PIP_EXTERNAL_DEPS_DOC,
                 )
 
-            if binary_filters is not None:
-                allowed_extensions = ALL_FILE_EXTENSIONS
-            else:
-                allowed_extensions = SDIST_FILE_EXTENSIONS
-
             url = urlparse.urlparse(req.url)
-            if not any(url.path.endswith(ext) for ext in allowed_extensions):
+            if not any(url.path.endswith(ext) for ext in ALL_FILE_EXTENSIONS):
                 msg = (
                     "URL for requirement does not contain any recognized file extension: "
-                    f"{req.download_line} (expected one of {', '.join(allowed_extensions)})"
+                    f"{req.download_line} (expected one of {', '.join(ALL_FILE_EXTENSIONS)})"
                 )
                 raise PackageRejected(msg, solution=None)
 

--- a/tests/unit/package_managers/pip/test_requirements.py
+++ b/tests/unit/package_managers/pip/test_requirements.py
@@ -4,30 +4,9 @@ from typing import Any, Union
 
 import pytest
 
-from hermeto.core.errors import PackageRejected, UnexpectedFormat, UnsupportedFeature
-from hermeto.core.models.input import PipBinaryFilters
-from hermeto.core.package_managers.pip.requirements import (
-    PipRequirement,
-    PipRequirementsFile,
-    validate_requirements,
-)
+from hermeto.core.errors import UnexpectedFormat, UnsupportedFeature
+from hermeto.core.package_managers.pip.requirements import PipRequirement, PipRequirementsFile
 from hermeto.core.rooted_path import RootedPath
-from tests.unit.package_managers.pip.test_main import mock_requirement
-
-
-def test_validate_whl_url_when_binaries_allowed() -> None:
-    url = "https://example.org/file.whl"
-    req = mock_requirement("foo", "url", url=url, download_line=f"foo @ {url}")
-
-    validate_requirements([req], PipBinaryFilters.with_allow_binary_behavior())
-
-
-def test_validate_whl_url_when_binaries_not_allowed() -> None:
-    url = "https://example.org/file.whl"
-    req = mock_requirement("foo", "url", url=url, download_line=f"foo @ {url}")
-
-    with pytest.raises(PackageRejected):
-        validate_requirements([req], None)
 
 
 class TestPipRequirementsFile:

--- a/tests/unit/package_managers/pip/test_requirements.py
+++ b/tests/unit/package_managers/pip/test_requirements.py
@@ -5,6 +5,7 @@ from typing import Any, Union
 import pytest
 
 from hermeto.core.errors import PackageRejected, UnexpectedFormat, UnsupportedFeature
+from hermeto.core.models.input import PipBinaryFilters
 from hermeto.core.package_managers.pip.requirements import (
     PipRequirement,
     PipRequirementsFile,
@@ -18,7 +19,7 @@ def test_validate_whl_url_when_binaries_allowed() -> None:
     url = "https://example.org/file.whl"
     req = mock_requirement("foo", "url", url=url, download_line=f"foo @ {url}")
 
-    validate_requirements([req], allow_binary=True)
+    validate_requirements([req], PipBinaryFilters.with_allow_binary_behavior())
 
 
 def test_validate_whl_url_when_binaries_not_allowed() -> None:
@@ -26,7 +27,7 @@ def test_validate_whl_url_when_binaries_not_allowed() -> None:
     req = mock_requirement("foo", "url", url=url, download_line=f"foo @ {url}")
 
     with pytest.raises(PackageRejected):
-        validate_requirements([req], allow_binary=False)
+        validate_requirements([req], None)
 
 
 class TestPipRequirementsFile:


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
