### PR TITLE
npm: set npm_config_build_from_source=true to handle prebuildify packages

### DIFF
--- a/hermeto/core/package_managers/javascript/npm/main.py
+++ b/hermeto/core/package_managers/javascript/npm/main.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-only
 from hermeto.core.models.input import Request
-from hermeto.core.models.output import ProjectFile, RequestOutput
+from hermeto.core.models.output import EnvironmentVariable, ProjectFile, RequestOutput
 from hermeto.core.models.property_semantics import PropertySet
 from hermeto.core.models.sbom import Component, create_backend_annotation
 from hermeto.core.package_managers.javascript.npm import project as npm_project
@@ -57,13 +57,20 @@ def fetch_npm_source(request: Request) -> RequestOutput:
         for projectfile in info["projectfiles"]:
             project_files.append(projectfile)
 
+    env_vars = [
+        EnvironmentVariable(
+            name="npm_config_build_from_source",
+            value="true",
+        ),
+    ]
+
     components = _generate_component_list(component_info)
     annotations = []
     if backend_annotation := create_backend_annotation(components, "npm"):
         annotations.append(backend_annotation)
     return RequestOutput.from_obj_list(
         components=components,
-        environment_variables=[],
+        environment_variables=env_vars,
         project_files=project_files,
         annotations=annotations,
     )

--- a/hermeto/core/package_managers/javascript/yarn/main.py
+++ b/hermeto/core/package_managers/javascript/yarn/main.py
@@ -323,6 +323,7 @@ def _generate_environment_variables() -> list[EnvironmentVariable]:
         "YARN_ENABLE_IMMUTABLE_CACHE": "false",
         "YARN_ENABLE_MIRROR": "true",
         "YARN_GLOBAL_FOLDER": "${output_dir}/deps/yarn",
+        "npm_config_build_from_source": "true",
     }
 
     return [EnvironmentVariable(name=key, value=value) for key, value in env_vars.items()]

--- a/hermeto/core/package_managers/javascript/yarn_classic/main.py
+++ b/hermeto/core/package_managers/javascript/yarn_classic/main.py
@@ -189,6 +189,7 @@ def _generate_build_environment_variables() -> list[EnvironmentVariable]:
     env_vars = {
         "YARN_YARN_OFFLINE_MIRROR": "${output_dir}/deps/yarn-classic",
         "YARN_YARN_OFFLINE_MIRROR_PRUNING": "false",
+        "npm_config_build_from_source": "true",
     }
 
     return [EnvironmentVariable(name=key, value=value) for key, value in env_vars.items()]

--- a/tests/unit/package_managers/javascript/npm/test_main.py
+++ b/tests/unit/package_managers/javascript/npm/test_main.py
@@ -106,7 +106,9 @@ from hermeto.core.package_managers.javascript.npm.project import NpmComponentInf
                     properties=[
                         Property(
                             name=f"{APP_NAME}:missing_hash:in_file",
-                            value="path/to/foo/package-lock.json",
+                            # Mirror str(Path(...)) that the production code uses so
+                            # the assertion holds on both POSIX and Windows.
+                            value=str(Path("path/to/foo/package-lock.json")),
                         ),
                     ],
                 ),
@@ -120,3 +122,4 @@ def test_generate_component_list(
     """Test _generate_component_list with different NpmComponentInfo inputs."""
     merged_components = _generate_component_list(components)
     assert merged_components == expected_components
+

--- a/tests/unit/package_managers/javascript/yarn/test_main.py
+++ b/tests/unit/package_managers/javascript/yarn/test_main.py
@@ -37,6 +37,7 @@ def yarn_env_variables() -> list[EnvironmentVariable]:
         EnvironmentVariable(name="YARN_ENABLE_IMMUTABLE_CACHE", value="false"),
         EnvironmentVariable(name="YARN_ENABLE_MIRROR", value="true"),
         EnvironmentVariable(name="YARN_GLOBAL_FOLDER", value="${output_dir}/deps/yarn"),
+        EnvironmentVariable(name="npm_config_build_from_source", value="true"),
     ]
 
 

--- a/tests/unit/package_managers/javascript/yarn_classic/test_main.py
+++ b/tests/unit/package_managers/javascript/yarn_classic/test_main.py
@@ -44,6 +44,7 @@ def yarn_classic_env_variables() -> list[EnvironmentVariable]:
             name="YARN_YARN_OFFLINE_MIRROR", value="${output_dir}/deps/yarn-classic"
         ),
         EnvironmentVariable(name="YARN_YARN_OFFLINE_MIRROR_PRUNING", value="false"),
+        EnvironmentVariable(name="npm_config_build_from_source", value="true"),
     ]
 
 


### PR DESCRIPTION
fixes #1015 

## Description
Resolves the first proposed solution from #1015.

Packages using [prebuildify](https://github.com/prebuild/prebuildify) ship precompiled native `.node` binaries under a `prebuilds/` directory. At install time, [`node-gyp-build`](https://github.com/prebuild/node-gyp-build) checks for the `npm_config_build_from_source` environment variable — if set, it compiles native addons from source instead of using the prebuilt binaries.

Without this fix, hermetic builds silently use prebuilt platform-specific binaries, undermining the hermetic build guarantee.

This PR injects `npm_config_build_from_source=true` into the build configuration output for all npm packages, ensuring native addons are always compiled from source.

## How to test

```bash
nox -s python-3.10 -- tests/unit/package_managers/test_npm.py -v
```

<img width="1435" height="357" alt="Screenshot 2026-03-12 182704" src="https://github.com/user-attachments/assets/f6991cf6-8228-4d5c-bcb4-2d89a256e6a1" />


```
============================= test session starts ==============================
collected 105 items

tests/unit/package_managers/test_npm.py::test_fetch_npm_source[single_input_package] PASSED
tests/unit/package_managers/test_npm.py::test_fetch_npm_source[multiple_input_package] PASSED
...
============================= 105 passed in 1.54s ==============================
```

As noted in the issue, we should do either or both of the proposed solutions. This PR implements Solution 1 as a standalone fix. Solution 2 (detecting and gating prebuilt packages) can be added as a follow-up PR if the maintainers agree it's needed.
