### PR TITLE
fix(tests): isolate git-reliant tests from developer config

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -32,6 +32,8 @@ def _create_git_repo(path: Path, files: dict[StrPath, FileContents] | None = Non
     repo = git.Repo.init(path)
     repo.git.config("user.name", "user")
     repo.git.config("user.email", "user@example.com")
+    repo.git.config("commit.gpgSign", "false")
+    repo.git.config("tag.gpgSign", "false")
 
     if files is not None:
         for file_path, content in files.items():

--- a/tests/unit/package_managers/gomod/test_main.py
+++ b/tests/unit/package_managers/gomod/test_main.py
@@ -68,8 +68,8 @@ from hermeto.core.package_managers.gomod.main import (
 )
 from hermeto.core.rooted_path import PathOutsideRoot, RootedPath
 from hermeto.core.scm import GitRepo, RepoID
-from hermeto.core.utils import GIT_PRISTINE_ENV
 from tests.common_utils import GIT_REF, write_file_tree
+from tests.unit.conftest import _create_git_repo
 from tests.unit.package_managers.gomod.helpers import get_mocked_data
 
 GO_CMD_PATH = "/usr/bin/go"
@@ -1098,56 +1098,32 @@ def test_parse_vendor_unexpected_format(
 
 @pytest.mark.parametrize("subpath", ["", "some/app/"])
 @pytest.mark.parametrize(
-    "vendor_before, vendor_changes, expected_change",
+    "vendor_before, vendor_changes, expected_changed_files",
     [
         pytest.param({}, {}, None, id="no_vendoring"),
         pytest.param({"vendor": {"modules.txt": "foo v1.0.0\n"}}, {}, None, id="no_changes"),
         pytest.param(
             {},
             {"vendor": {"modules.txt": "foo v1.0.0\n"}},
-            textwrap.dedent(
-                """
-                --- /dev/null
-                +++ b/{subpath}vendor/modules.txt
-                @@ -0,0 +1 @@
-                +foo v1.0.0
-                """
-            ),
+            ["{subpath}vendor/modules.txt"],
             id="modules_txt_added",
         ),
         pytest.param(
             {"vendor": {"modules.txt": "foo v1.0.0\n"}},
             {"vendor": {"modules.txt": "foo v2.0.0\n"}},
-            textwrap.dedent(
-                """
-                --- a/{subpath}vendor/modules.txt
-                +++ b/{subpath}vendor/modules.txt
-                @@ -1 +1 @@
-                -foo v1.0.0
-                +foo v2.0.0
-                """
-            ),
+            ["{subpath}vendor/modules.txt"],
             id="modules_txt_changes",
         ),
         pytest.param(
             {},
             {"vendor": {"some_file": "foo"}},
-            textwrap.dedent(
-                """
-                A\t{subpath}vendor/some_file
-                """
-            ),
+            ["{subpath}vendor directory"],
             id="a_file_was_added",
         ),
         pytest.param(
             {"vendor": {"some_file": "foo"}},
             {"vendor": {"some_file": "bar", "other_file": "baz"}},
-            textwrap.dedent(
-                """
-                A\t{subpath}vendor/other_file
-                M\t{subpath}vendor/some_file
-                """
-            ),
+            ["{subpath}vendor directory"],
             id="multiple_changes",
         ),
         # vendor/ was added but only contains empty dirs => will be ignored
@@ -1156,11 +1132,7 @@ def test_parse_vendor_unexpected_format(
         pytest.param(
             {".gitignore": "vendor/"},
             {"vendor": {"some_file": "foo"}},
-            textwrap.dedent(
-                """
-                A\t{subpath}vendor/some_file
-                """
-            ),
+            ["{subpath}vendor directory"],
             id="file_added_in_gitignored_vendor_dir",
         ),
     ],
@@ -1169,7 +1141,7 @@ def test_vendor_changed(
     subpath: str,
     vendor_before: dict[str, Any],
     vendor_changes: dict[str, Any],
-    expected_change: str | None,
+    expected_changed_files: list[str] | None,
     rooted_tmp_path_repo: RootedPath,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -1184,9 +1156,10 @@ def test_vendor_changed(
 
     write_file_tree(vendor_changes, app_dir, exist_ok=True)
 
-    assert _vendor_changed(app_dir) == bool(expected_change)
-    if expected_change:
-        assert expected_change.format(subpath=subpath) in caplog.text
+    assert _vendor_changed(app_dir) == bool(expected_changed_files)
+    if expected_changed_files:
+        for f in expected_changed_files:
+            assert f.format(subpath=subpath) in caplog.text
 
     # The _vendor_changed function should reset the `git add` => added files should not be tracked
     assert not repo.git.diff("--diff-filter", "A")
@@ -1553,7 +1526,7 @@ def repo_remote_with_tag(rooted_tmp_path: RootedPath) -> tuple[RootedPath, Roote
 
     local_repo_path.path.mkdir()
     remote_repo_path.path.mkdir()
-    remote_repo = git.Repo.init(remote_repo_path)
+    remote_repo = _create_git_repo(remote_repo_path.path)
 
     with open(readme_file_path, "wb"):
         pass
@@ -1567,8 +1540,8 @@ def repo_remote_with_tag(rooted_tmp_path: RootedPath) -> tuple[RootedPath, Roote
 
     git.Repo.clone_from(remote_repo_path, local_repo_path)
 
-    remote_repo.create_tag("v1.0.0", ref=initial_commit, env=GIT_PRISTINE_ENV)
-    remote_repo.create_tag("v2.0.0", env=GIT_PRISTINE_ENV)
+    remote_repo.create_tag("v1.0.0", ref=initial_commit)
+    remote_repo.create_tag("v2.0.0")
 
     return remote_repo_path, local_repo_path
 


### PR DESCRIPTION
Fixes #1059

### Description
Currently, several Git-reliant unit tests randomly fail if developers have customized certain configurations in their global ~/.gitconfig. Most notably:

1. [diff] noprefix = true breaks test_vendor_changed (which incorrectly asserts the exact git diff output formatting including 
a/ prefixes).
2. [init] defaultBranch = main and [tag] gpgSign = true can break various internal repository operations.

Previous PR attempts to solve similar problems used env=GIT_PRISTINE_ENV (which forces GIT_CONFIG_GLOBAL=/dev/null). However, as noted in the issue, completely suppressing the global config this way caused unintended side-effects with git credentials on integration runs.

### Verify
 verify the robustness of this test isolation by creating a highly disruptive dummy config and forcing tests to read it:

1. Create dummy_gitconfig:

``` [tag]
    gpgSign = true
[diff]
    noprefix = true
[init]
    defaultBranch = main
[commit]
    gpgSign = true
```

2. Run the gomod test suite:

```
GIT_CONFIG_GLOBAL=$(pwd)/dummy_gitconfig pytest tests/unit/package_managers/test_gomod.py 
```

### BEFORE:  

<img width="1228" height="227" alt="Screenshot 2026-03-20 100149" src="https://github.com/user-attachments/assets/d941ee0f-50ed-4ea3-a102-c64009af2fb2" />


### AFTER:

<img width="1041" height="782" alt="Screenshot 2026-03-20 095846" src="https://github.com/user-attachments/assets/dd2c17ac-010d-4a0b-9795-a244fdbc51b1" />

<img width="1057" height="787" alt="Screenshot 2026-03-20 095802" src="https://github.com/user-attachments/assets/7efc4627-3168-4b03-b863-3b053a3f22dd" />

(Note regarding test output: Test runs may currently emit PytestDeprecationWarning: asyncio_default_fixture_loop_scope is unset and pkg_resources.declare_namespace('google') deprecation warnings. These are pre-existing warnings from third-party libraries interacting with Python 3.12 and are entirely unrelated to the git configuration fixes in this PR).