### PR TITLE
feat(bundler): checksum validation for bundler

### DIFF
--- a/hermeto/core/package_managers/bundler/main.py
+++ b/hermeto/core/package_managers/bundler/main.py
@@ -10,6 +10,7 @@ import aiohttp
 from packageurl import PackageURL
 
 from hermeto import APP_NAME
+from hermeto.core.checksum import ChecksumInfo, must_match_any_checksum
 from hermeto.core.config import get_config
 from hermeto.core.constants import Mode
 from hermeto.core.errors import NotAGitRepo, PackageRejected, UnsupportedFeature
@@ -142,6 +143,24 @@ def _download_gems(
             headers=headers,
         )
     )
+
+    verify_checksums(gem_deps, deps_dir)
+
+
+def verify_checksums(
+    gem_deps: list[GemDependency],
+    deps_dir: RootedPath,
+) -> None:
+    """Verify checksums for downloaded gems."""
+    for dep in gem_deps:
+        if dep.checksum is None:
+            log.warning("No checksum found for %s-%s, skipping verification", dep.name, dep.version)
+            continue
+
+        must_match_any_checksum(
+            dep.download_location(deps_dir).path,
+            [ChecksumInfo.from_hash(dep.checksum)],
+        )
 
 
 def _clone_git_deps(

--- a/hermeto/core/package_managers/bundler/main.py
+++ b/hermeto/core/package_managers/bundler/main.py
@@ -10,6 +10,7 @@ import aiohttp
 from packageurl import PackageURL
 
 from hermeto import APP_NAME
+from hermeto.core.checksum import ChecksumInfo, must_match_any_checksum
 from hermeto.core.config import get_config
 from hermeto.core.constants import Mode
 from hermeto.core.errors import NotAGitRepo, PackageRejected, UnsupportedFeature
@@ -143,6 +144,23 @@ def _download_gems(
             headers=headers,
         )
     )
+
+    _verify_checksums(gem_deps, deps_dir)
+
+
+def _verify_checksums(
+    gem_deps: list[GemDependency],
+    deps_dir: RootedPath,
+) -> None:
+    for dep in gem_deps:
+        if dep.checksum is None:
+            log.warning("No checksum found for %s-%s, skipping verification", dep.name, dep.version)
+            continue
+
+        must_match_any_checksum(
+            dep.download_location(deps_dir).path,
+            [ChecksumInfo.from_hash(checksum) for checksum in dep.checksum.split()],
+        )
 
 
 def _clone_git_deps(

--- a/hermeto/core/package_managers/bundler/parser.py
+++ b/hermeto/core/package_managers/bundler/parser.py
@@ -59,7 +59,7 @@ def parse_lockfile(
         if dep["type"] == "rubygems":
             for platform in dep["platforms"]:
                 if platform == "ruby":
-                    result.append(GemDependency(**dep))
+                    result.append(GemDependency(checksum=dep["checksums"].get(platform), **dep))
                 else:
                     full_name = "-".join([dep["name"], dep["version"], platform])
                     log.info("Found a binary dependency %s", full_name)
@@ -68,7 +68,11 @@ def parse_lockfile(
                             "Will download binary dependency %s because 'binary' field is set",
                             full_name,
                         )
-                        result.append(GemPlatformSpecificDependency(platform=platform, **dep))
+                        result.append(
+                            GemPlatformSpecificDependency(
+                                platform=platform, checksum=dep["checksums"].get(platform), **dep
+                            )
+                        )
                     else:
                         # No need to force a platform if we skip the packages.
                         log.warning(

--- a/hermeto/core/package_managers/bundler/parser.py
+++ b/hermeto/core/package_managers/bundler/parser.py
@@ -92,7 +92,7 @@ def parse_lockfile(
         if dep["type"] == "rubygems":
             for platform in dep["platforms"]:
                 if platform == "ruby":
-                    result.append(GemDependency(**dep))
+                    result.append(GemDependency(checksum=dep["checksums"].get(platform), **dep))
                 else:
                     full_name = "-".join([dep["name"], dep["version"], platform])
                     log.info("Found a binary dependency %s", full_name)
@@ -101,7 +101,11 @@ def parse_lockfile(
                             "Will download binary dependency %s because 'binary' field is set",
                             full_name,
                         )
-                        result.append(GemPlatformSpecificDependency(platform=platform, **dep))
+                        result.append(
+                            GemPlatformSpecificDependency(
+                                platform=platform, checksum=dep["checksums"].get(platform), **dep
+                            )
+                        )
                     else:
                         # No need to force a platform if we skip the packages.
                         log.warning(

--- a/hermeto/core/package_managers/bundler/scripts/lockfile_parser.rb
+++ b/hermeto/core/package_managers/bundler/scripts/lockfile_parser.rb
@@ -11,12 +11,29 @@ parsed_specs = []
 lockfile_parser.specs.each do |spec|
     case spec.source
     when Bundler::Source::Rubygems
+      # Requires Bundler 2.5.0+ to resolve field.
+      # e.g. input:  gem_lock_name sha256=hash,...
+      #      output: sha256:hash sha....
+      lock_content = spec.source.checksum_store.to_lock(spec)
+      pattern = /^#{Regexp.escape(spec.lock_name)} (.*)/
+
+      checksums_raw = lock_content[pattern, 1]
+      if checksums_raw == nil
+        checksum = nil
+      else
+        checksum = checksums_raw
+          .split(",")
+          .map { |c| c.sub("=", ":") }
+          .join(" ")                         
+      end
+
       parsed_spec = {
         name: spec.name,
         version: spec.version,
         type: 'rubygems',
         source: spec.source.remotes.first,
-        platforms: [spec.platform]
+        platforms: [spec.platform],
+        checksums: checksum.nil? ? {} : { spec.platform => checksum }
       }
 
       existing_spec = parsed_specs.find { |s|
@@ -27,8 +44,9 @@ lockfile_parser.specs.each do |spec|
       }
 
       if existing_spec
-        # extend the platforms array
-        existing_spec[:platforms] << parsed_spec[:platforms].first
+        # extend the platforms array and checksums dictionary
+        existing_spec[:platforms] |= parsed_spec[:platforms]
+        existing_spec[:checksums].merge!(parsed_spec[:checksums])
       else
         parsed_specs << parsed_spec
       end
@@ -57,4 +75,4 @@ lockfile_parser.specs.each do |spec|
 puts JSON.pretty_generate({ bundler_version: lockfile_parser.bundler_version, dependencies: parsed_specs })
 
 # References:
-# https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/lockfile_parser.rb
+# https://github.com/ruby/rubygems/blob/master/lib/bundler/lockfile_parser.rb

--- a/hermeto/core/package_managers/bundler/scripts/lockfile_parser.rb
+++ b/hermeto/core/package_managers/bundler/scripts/lockfile_parser.rb
@@ -11,12 +11,14 @@ parsed_specs = []
 lockfile_parser.specs.each do |spec|
     case spec.source
     when Bundler::Source::Rubygems
+      checksum = spec.source.checksum_store.to_lock(spec)[/sha[^, ]*/]&.sub("=",":")
       parsed_spec = {
         name: spec.name,
         version: spec.version,
         type: 'rubygems',
         source: spec.source.remotes.first,
-        platforms: [spec.platform]
+        platforms: [spec.platform],
+        checksums: checksum.nil? ? {} : { spec.platform => checksum }
       }
 
       existing_spec = parsed_specs.find { |s|
@@ -27,8 +29,9 @@ lockfile_parser.specs.each do |spec|
       }
 
       if existing_spec
-        # extend the platforms array
-        existing_spec[:platforms] << parsed_spec[:platforms].first
+        # extend the platforms array and checksums dictionary
+        existing_spec[:platforms] |= parsed_spec[:platforms]
+        existing_spec[:checksums].merge!(parsed_spec[:checksums])
       else
         parsed_specs << parsed_spec
       end
@@ -57,4 +60,4 @@ lockfile_parser.specs.each do |spec|
 puts JSON.pretty_generate({ bundler_version: lockfile_parser.bundler_version, dependencies: parsed_specs })
 
 # References:
-# https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/lockfile_parser.rb
+# https://github.com/ruby/rubygems/blob/master/lib/bundler/lockfile_parser.rb

--- a/tests/integration/bundler/scenarios/bundler_checksum_mismatch/in/Containerfile
+++ b/tests/integration/bundler/scenarios/bundler_checksum_mismatch/in/Containerfile
@@ -1,0 +1,12 @@
+FROM mirror.gcr.io/ruby:3.3
+
+RUN if curl -IsS www.google.com; then echo "Has network access!"; exit 1; fi
+
+WORKDIR /app
+
+COPY Gemfile .
+COPY Gemfile.lock .
+
+RUN bundle install --local
+
+CMD ["rails", "-v"]

--- a/tests/integration/bundler/scenarios/bundler_checksum_mismatch/in/Gemfile
+++ b/tests/integration/bundler/scenarios/bundler_checksum_mismatch/in/Gemfile
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "racc", "~> 1.8"

--- a/tests/integration/bundler/scenarios/bundler_checksum_mismatch/in/Gemfile.lock
+++ b/tests/integration/bundler/scenarios/bundler_checksum_mismatch/in/Gemfile.lock
@@ -1,0 +1,18 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    racc (1.8.1)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  racc (~> 1.8)
+
+CHECKSUMS
+  bundler (4.0.15) sha256=a4ceb882fe94a0e0ac63cd0813932bbfd631a14e5ac0b7975189b19a4d28d9e7
+  racc (1.8.1) sha256=4a7f6729671dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa671303d62f
+
+BUNDLED WITH
+  4.0.15

--- a/tests/integration/bundler/scenarios/bundler_checksum_mismatch/in/README.md
+++ b/tests/integration/bundler/scenarios/bundler_checksum_mismatch/in/README.md
@@ -1,0 +1,2 @@
+# hermeto-testing
+Tests bundler checksum mismatch and expects ERR_CHECKSUM_VERIFICATION_FAILED

--- a/tests/integration/bundler/scenarios/bundler_checksum_mismatch/in/README.md
+++ b/tests/integration/bundler/scenarios/bundler_checksum_mismatch/in/README.md
@@ -1,0 +1,3 @@
+# hermeto-testing
+Tests bundler checksum mismatch and expects ERR_CHECKSUM_VERIFICATION_FAILED
+incorrect checksum in racc gem

--- a/tests/integration/bundler/scenarios/bundler_e2e_ruby33/in/Gemfile.lock
+++ b/tests/integration/bundler/scenarios/bundler_e2e_ruby33/in/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     concurrent-ruby (1.3.4)
     crass (1.0.6)
     date (3.3.4)
+    drb (2.2.3)
     erubi (1.13.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -104,7 +105,10 @@ GEM
     marcel (1.0.4)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    minitest (5.25.1)
+    mini_portile2 (2.8.9)
+    minitest (6.0.6)
+      drb (~> 2.0)
+      prism (~> 1.5)
     net-imap (0.4.16)
       date
       net-protocol
@@ -115,6 +119,9 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
+    nokogiri (1.16.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.16.7-aarch64-linux)
       racc (~> 1.4)
     nokogiri (1.16.7-arm-linux)
@@ -127,6 +134,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
+    prism (1.9.0)
     public_suffix (6.0.1)
     racc (1.8.1)
     rack (2.2.9)
@@ -193,5 +201,68 @@ DEPENDENCIES
   rails (= 6.1.7)
   tmp!
 
+CHECKSUMS
+  actioncable (6.1.7) sha256=ee5345e1ac0a9ec24af8d21d46d6e8d85dd76b28b14ab60929c2da3e7d5bfe64
+  actionmailbox (6.1.7) sha256=c4364381e724b39eee3381e6eb3fdc80f121ac9a53dea3fd9ef687a9040b8a08
+  actionmailer (6.1.7) sha256=5561c298a13e6d43eb71098be366f59be51470358e6e6e49ebaaf43502906fa4
+  actionpack (6.1.7) sha256=3a8580e3721757371328906f953b332d5c95bd56a1e4f344b3fee5d55dc1cf37
+  actiontext (6.1.7) sha256=c5d3af4168619923d0ff661207215face3e03f7a04c083b5d347f190f639798e
+  actionview (6.1.7) sha256=c166e890d2933ffbb6eb2a2eac1b54f03890e33b8b7269503af848db88afc8d4
+  activejob (6.1.7) sha256=e5d2ac525b6be5ccf242534af504ea2c7b406fb5f7880495ce3c1407e749c415
+  activemodel (6.1.7) sha256=7ec2b54676e30b523b2af16f027d74304a49d3cba83e2c400b3cf3dd153d6da0
+  activerecord (6.1.7) sha256=52e4a2601bb41b87db2be68c3f62add64c4614b580f9b540131d7a3e028a5db7
+  activestorage (6.1.7) sha256=e0af9a8fc6a2b92172c1061bc546f6c47b1f3b5d94b63f2aaaea68a1a6db75fb
+  activesupport (6.1.7) sha256=f9dee8a4cc315714e29228328428437c8779f58237749339afadbdcfb5c0b74c
+  addressable (2.8.7) sha256=462986537cf3735ab5f3c0f557f14155d778f4b43ea4f485a9deb9c8f7c58232
+  builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
+  concurrent-ruby (1.3.4) sha256=d4aa926339b0a86b5b5054a0a8c580163e6f5dcbdfd0f4bb916b1a2570731c32
+  crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
+  date (3.3.4) sha256=971f2cb66b945bcbea4ddd9c7908c9400b31a71bc316833cb42fa584b59d3291
+  drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  erubi (1.13.0) sha256=fca61b47daefd865d0fb50d168634f27ad40181867445badf6427c459c33cd62
+  globalid (1.2.1) sha256=70bf76711871f843dbba72beb8613229a49429d1866828476f9c9d6ccc327ce9
+  i18n (1.14.6) sha256=dc229a74f5d181f09942dd60ab5d6e667f7392c4ee826f35096db36d1fe3614c
+  json-schema (3.0.0)
+  loofah (2.22.0) sha256=10d76e070c86b12fec74b6a9515fd1940f4459198b991342d0a7897d86c372fe
+  mail (2.8.1) sha256=ec3b9fadcf2b3755c78785cb17bc9a0ca9ee9857108a64b6f5cfc9c0b5bfc9ad
+  marcel (1.0.4) sha256=0d5649feb64b8f19f3d3468b96c680bae9746335d02194270287868a661516a4
+  method_source (1.1.0) sha256=181301c9c45b731b4769bc81e8860e72f9161ad7d66dd99103c9ab84f560f5c5
+  mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
+  mini_portile2 (2.8.9) sha256=0cd7c7f824e010c072e33f68bc02d85a00aeb6fce05bb4819c03dfd3c140c289
+  minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
+  mygem (0.0.1) sha256=76acd744bb980a4b2b1f6747e5b96d2ca25e4f44b597dc337a00e3b4132258e5
+  net-imap (0.4.16) sha256=70e104926f042e30e2fd3b4c2632cc97661762d6e09679e5fc9be4a346d43243
+  net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
+  net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
+  net-smtp (0.5.0) sha256=5fc0415e6ea1cc0b3dfea7270438ec22b278ca8d524986a3ae4e5ae8d087b42a
+  nio4r (2.7.3) sha256=54b94cdd4b8f9dc39aaad5f699e97afae13efb44f2b180a6e724df76105ff604
+  nokogiri (1.16.7) sha256=f819cbfdfb0a7b19c9c52c6f2ca63df0e58a6125f4f139707b586b9511d7fe95
+  nokogiri (1.16.7-aarch64-linux) sha256=78778d35f165b59513be31c0fe232c63a82cf97626ffba695b5f822e5da1d74b
+  nokogiri (1.16.7-arm-linux) sha256=c84cdb9e3aa44c35bbb981b20175838c4b2066c26c5cb118f31f177168a42fc3
+  nokogiri (1.16.7-arm64-darwin) sha256=276dcea1b988a5b22b5acc1ba901d24b8e908c40b71dccd5d54a2ae279480dad
+  nokogiri (1.16.7-x86-linux) sha256=dddbf1c1ef99ce9fab98302b14f8bacb703e6f16e89b99f05ecee8a1fca23664
+  nokogiri (1.16.7-x86_64-darwin) sha256=630732b80fc572690eab50c73a1f18988f3ac401ed0b67ca9956ba2b1e2c3faa
+  nokogiri (1.16.7-x86_64-linux) sha256=9e1e428641d5942af877c60b418c71163560e9feb4a5c4015f3230a8b86a40f6
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  public_suffix (6.0.1) sha256=61d44e1cab5cbbbe5b31068481cf16976dd0dc1b6b07bd95617ef8c5e3e00c6f
+  quux (0.0.1)
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rack (2.2.9) sha256=fd6301a97a1c1e955e68f85c861fcb1cde6145a32c532e1ea321a72ff8cc4042
+  rack-test (2.1.0) sha256=0c61fc61904049d691922ea4bb99e28004ed3f43aa5cfd495024cc345f125dfb
+  rails (6.1.7) sha256=6e3b9226fb9f82d916990b7da9a121191890ed20ac49f40e902d4e6952308006
+  rails-dom-testing (2.2.0) sha256=e515712e48df1f687a1d7c380fd7b07b8558faa26464474da64183a7426fa93b
+  rails-html-sanitizer (1.6.0) sha256=86e9f19d2e6748890dcc2633c8945ca45baa08a1df9d8c215ce17b3b0afaa4de
+  railties (6.1.7) sha256=5df0960e55db0edd305de26f7a3cf7da695c035cd6cd5bf8c8c79df9338e9fc7
+  rake (13.2.1) sha256=46cb38dae65d7d74b6020a4ac9d48afed8eb8149c040eccf0523bec91907059d
+  sprockets (4.2.1) sha256=951b13dd2f2fcae840a7184722689a803e0ff9d2702d902bd844b196da773f97
+  sprockets-rails (3.5.2) sha256=a9e88e6ce9f8c912d349aa5401509165ec42326baf9e942a85de4b76dbc4119e
+  thor (1.3.2) sha256=eef0293b9e24158ccad7ab383ae83534b7ad4ed99c09f96f1a6b036550abbeda
+  timeout (0.4.1) sha256=6f1f4edd4bca28cffa59501733a94215407c6960bd2107331f0280d4abdebb9a
+  tmp (0.1.2)
+  tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
+  websocket-driver (0.7.6) sha256=f69400be7bc197879726ad8e6f5869a61823147372fd8928836a53c2c741d0db
+  websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
+  zeitwerk (2.6.18) sha256=bd2d213996ff7b3b364cd342a585fbee9797dbc1c0c6d868dc4150cc75739781
+
 BUNDLED WITH
-   2.5.16
+  4.0.16

--- a/tests/integration/bundler/scenarios/bundler_e2e_ruby33/out/bom.json
+++ b/tests/integration/bundler/scenarios/bundler_e2e_ruby33/out/bom.json
@@ -23,6 +23,7 @@
         "pkg:gem/concurrent-ruby@1.3.4",
         "pkg:gem/crass@1.0.6",
         "pkg:gem/date@3.3.4",
+        "pkg:gem/drb@2.2.3",
         "pkg:gem/erubi@1.13.0",
         "pkg:gem/globalid@1.2.1",
         "pkg:gem/i18n@1.14.6",
@@ -32,7 +33,8 @@
         "pkg:gem/marcel@1.0.4",
         "pkg:gem/method_source@1.1.0",
         "pkg:gem/mini_mime@1.1.5",
-        "pkg:gem/minitest@5.25.1",
+        "pkg:gem/mini_portile2@2.8.9",
+        "pkg:gem/minitest@6.0.6",
         "pkg:gem/mygem@0.0.1",
         "pkg:gem/net-imap@0.4.16",
         "pkg:gem/net-pop@0.1.2",
@@ -40,8 +42,9 @@
         "pkg:gem/net-smtp@0.5.0",
         "pkg:gem/nio4r@2.7.3",
         "pkg:gem/nokogiri@1.16.7",
+        "pkg:gem/prism@1.9.0",
         "pkg:gem/public_suffix@6.0.1",
-        "pkg:gem/quux@0.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40706615d41b8e57f5bfe67e2fca595b8a425b68c6#quux",
+        "pkg:gem/quux@0.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40a95ceee5d3cf1a4521422a4e74ffcad4227a86e0#quux",
         "pkg:gem/racc@1.8.1",
         "pkg:gem/rack-test@2.1.0",
         "pkg:gem/rack@2.2.9",
@@ -54,7 +57,7 @@
         "pkg:gem/sprockets@4.2.1",
         "pkg:gem/thor@1.3.2",
         "pkg:gem/timeout@0.4.1",
-        "pkg:gem/tmp@0.1.2?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40706615d41b8e57f5bfe67e2fca595b8a425b68c6",
+        "pkg:gem/tmp@0.1.2?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40a95ceee5d3cf1a4521422a4e74ffcad4227a86e0",
         "pkg:gem/tzinfo@2.0.6",
         "pkg:gem/websocket-driver@0.7.6",
         "pkg:gem/websocket-extensions@0.1.5",
@@ -275,6 +278,19 @@
       "version": "3.3.4"
     },
     {
+      "bom-ref": "pkg:gem/drb@2.2.3",
+      "name": "drb",
+      "properties": [
+        {
+          "name": "hermeto:found_by",
+          "value": "hermeto"
+        }
+      ],
+      "purl": "pkg:gem/drb@2.2.3",
+      "type": "library",
+      "version": "2.2.3"
+    },
+    {
       "bom-ref": "pkg:gem/erubi@1.13.0",
       "name": "erubi",
       "properties": [
@@ -392,7 +408,20 @@
       "version": "1.1.5"
     },
     {
-      "bom-ref": "pkg:gem/minitest@5.25.1",
+      "bom-ref": "pkg:gem/mini_portile2@2.8.9",
+      "name": "mini_portile2",
+      "properties": [
+        {
+          "name": "hermeto:found_by",
+          "value": "hermeto"
+        }
+      ],
+      "purl": "pkg:gem/mini_portile2@2.8.9",
+      "type": "library",
+      "version": "2.8.9"
+    },
+    {
+      "bom-ref": "pkg:gem/minitest@6.0.6",
       "name": "minitest",
       "properties": [
         {
@@ -400,9 +429,9 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:gem/minitest@5.25.1",
+      "purl": "pkg:gem/minitest@6.0.6",
       "type": "library",
-      "version": "5.25.1"
+      "version": "6.0.6"
     },
     {
       "bom-ref": "pkg:gem/mygem@0.0.1",
@@ -500,6 +529,19 @@
       "version": "1.16.7"
     },
     {
+      "bom-ref": "pkg:gem/prism@1.9.0",
+      "name": "prism",
+      "properties": [
+        {
+          "name": "hermeto:found_by",
+          "value": "hermeto"
+        }
+      ],
+      "purl": "pkg:gem/prism@1.9.0",
+      "type": "library",
+      "version": "1.9.0"
+    },
+    {
       "bom-ref": "pkg:gem/public_suffix@6.0.1",
       "name": "public_suffix",
       "properties": [
@@ -513,7 +555,7 @@
       "version": "6.0.1"
     },
     {
-      "bom-ref": "pkg:gem/quux@0.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40706615d41b8e57f5bfe67e2fca595b8a425b68c6#quux",
+      "bom-ref": "pkg:gem/quux@0.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40a95ceee5d3cf1a4521422a4e74ffcad4227a86e0#quux",
       "name": "quux",
       "properties": [
         {
@@ -521,7 +563,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:gem/quux@0.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40706615d41b8e57f5bfe67e2fca595b8a425b68c6#quux",
+      "purl": "pkg:gem/quux@0.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40a95ceee5d3cf1a4521422a4e74ffcad4227a86e0#quux",
       "type": "library",
       "version": "0.0.1"
     },
@@ -682,7 +724,7 @@
       "version": "0.4.1"
     },
     {
-      "bom-ref": "pkg:gem/tmp@0.1.2?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40706615d41b8e57f5bfe67e2fca595b8a425b68c6",
+      "bom-ref": "pkg:gem/tmp@0.1.2?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40a95ceee5d3cf1a4521422a4e74ffcad4227a86e0",
       "name": "tmp",
       "properties": [
         {
@@ -690,7 +732,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:gem/tmp@0.1.2?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40706615d41b8e57f5bfe67e2fca595b8a425b68c6",
+      "purl": "pkg:gem/tmp@0.1.2?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40a95ceee5d3cf1a4521422a4e74ffcad4227a86e0",
       "type": "library",
       "version": "0.1.2"
     },

--- a/tests/integration/bundler/scenarios/bundler_e2e_ruby40/out/bom.json
+++ b/tests/integration/bundler/scenarios/bundler_e2e_ruby40/out/bom.json
@@ -23,6 +23,7 @@
         "pkg:gem/concurrent-ruby@1.3.4",
         "pkg:gem/crass@1.0.6",
         "pkg:gem/date@3.3.4",
+        "pkg:gem/drb@2.2.3",
         "pkg:gem/erubi@1.13.0",
         "pkg:gem/globalid@1.2.1",
         "pkg:gem/i18n@1.14.6",
@@ -32,7 +33,8 @@
         "pkg:gem/marcel@1.0.4",
         "pkg:gem/method_source@1.1.0",
         "pkg:gem/mini_mime@1.1.5",
-        "pkg:gem/minitest@5.25.1",
+        "pkg:gem/mini_portile2@2.8.9",
+        "pkg:gem/minitest@6.0.6",
         "pkg:gem/mygem@0.0.1",
         "pkg:gem/net-imap@0.4.16",
         "pkg:gem/net-pop@0.1.2",
@@ -40,8 +42,9 @@
         "pkg:gem/net-smtp@0.5.0",
         "pkg:gem/nio4r@2.7.3",
         "pkg:gem/nokogiri@1.16.7",
+        "pkg:gem/prism@1.9.0",
         "pkg:gem/public_suffix@6.0.1",
-        "pkg:gem/quux@0.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40706615d41b8e57f5bfe67e2fca595b8a425b68c6#quux",
+        "pkg:gem/quux@0.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40a95ceee5d3cf1a4521422a4e74ffcad4227a86e0#quux",
         "pkg:gem/racc@1.8.1",
         "pkg:gem/rack-test@2.1.0",
         "pkg:gem/rack@2.2.9",
@@ -54,7 +57,7 @@
         "pkg:gem/sprockets@4.2.1",
         "pkg:gem/thor@1.3.2",
         "pkg:gem/timeout@0.4.1",
-        "pkg:gem/tmp@0.1.2?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40706615d41b8e57f5bfe67e2fca595b8a425b68c6",
+        "pkg:gem/tmp@0.1.2?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40a95ceee5d3cf1a4521422a4e74ffcad4227a86e0",
         "pkg:gem/tzinfo@2.0.6",
         "pkg:gem/websocket-driver@0.7.6",
         "pkg:gem/websocket-extensions@0.1.5",
@@ -275,6 +278,19 @@
       "version": "3.3.4"
     },
     {
+      "bom-ref": "pkg:gem/drb@2.2.3",
+      "name": "drb",
+      "properties": [
+        {
+          "name": "hermeto:found_by",
+          "value": "hermeto"
+        }
+      ],
+      "purl": "pkg:gem/drb@2.2.3",
+      "type": "library",
+      "version": "2.2.3"
+    },
+    {
       "bom-ref": "pkg:gem/erubi@1.13.0",
       "name": "erubi",
       "properties": [
@@ -392,7 +408,20 @@
       "version": "1.1.5"
     },
     {
-      "bom-ref": "pkg:gem/minitest@5.25.1",
+      "bom-ref": "pkg:gem/mini_portile2@2.8.9",
+      "name": "mini_portile2",
+      "properties": [
+        {
+          "name": "hermeto:found_by",
+          "value": "hermeto"
+        }
+      ],
+      "purl": "pkg:gem/mini_portile2@2.8.9",
+      "type": "library",
+      "version": "2.8.9"
+    },
+    {
+      "bom-ref": "pkg:gem/minitest@6.0.6",
       "name": "minitest",
       "properties": [
         {
@@ -400,9 +429,9 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:gem/minitest@5.25.1",
+      "purl": "pkg:gem/minitest@6.0.6",
       "type": "library",
-      "version": "5.25.1"
+      "version": "6.0.6"
     },
     {
       "bom-ref": "pkg:gem/mygem@0.0.1",
@@ -500,6 +529,19 @@
       "version": "1.16.7"
     },
     {
+      "bom-ref": "pkg:gem/prism@1.9.0",
+      "name": "prism",
+      "properties": [
+        {
+          "name": "hermeto:found_by",
+          "value": "hermeto"
+        }
+      ],
+      "purl": "pkg:gem/prism@1.9.0",
+      "type": "library",
+      "version": "1.9.0"
+    },
+    {
       "bom-ref": "pkg:gem/public_suffix@6.0.1",
       "name": "public_suffix",
       "properties": [
@@ -513,7 +555,7 @@
       "version": "6.0.1"
     },
     {
-      "bom-ref": "pkg:gem/quux@0.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40706615d41b8e57f5bfe67e2fca595b8a425b68c6#quux",
+      "bom-ref": "pkg:gem/quux@0.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40a95ceee5d3cf1a4521422a4e74ffcad4227a86e0#quux",
       "name": "quux",
       "properties": [
         {
@@ -521,7 +563,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:gem/quux@0.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40706615d41b8e57f5bfe67e2fca595b8a425b68c6#quux",
+      "purl": "pkg:gem/quux@0.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40a95ceee5d3cf1a4521422a4e74ffcad4227a86e0#quux",
       "type": "library",
       "version": "0.0.1"
     },
@@ -682,7 +724,7 @@
       "version": "0.4.1"
     },
     {
-      "bom-ref": "pkg:gem/tmp@0.1.2?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40706615d41b8e57f5bfe67e2fca595b8a425b68c6",
+      "bom-ref": "pkg:gem/tmp@0.1.2?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40a95ceee5d3cf1a4521422a4e74ffcad4227a86e0",
       "name": "tmp",
       "properties": [
         {
@@ -690,7 +732,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:gem/tmp@0.1.2?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40706615d41b8e57f5bfe67e2fca595b8a425b68c6",
+      "purl": "pkg:gem/tmp@0.1.2?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40a95ceee5d3cf1a4521422a4e74ffcad4227a86e0",
       "type": "library",
       "version": "0.1.2"
     },

--- a/tests/integration/bundler/test_bundler.py
+++ b/tests/integration/bundler/test_bundler.py
@@ -39,6 +39,15 @@ SCENARIOS_DIR = Path(__file__).parent / "scenarios"
             ),
             id="bundler_missing_git_revision",
         ),
+        pytest.param(
+            utils.TestParameters(
+                packages=({"path": ".", "type": "bundler"},),
+                check_output=False,
+                expected_error=ExitError.ERR_CHECKSUM_VERIFICATION_FAILED,
+                expected_output="Failed to verify",
+            ),
+            id="bundler_checksum_mismatch",
+        ),
     ],
 )
 def test_bundler_packages(

--- a/tests/unit/package_managers/bundler/test_parser.py
+++ b/tests/unit/package_managers/bundler/test_parser.py
@@ -135,6 +135,7 @@ def test_parse_gemlock(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     base_dep: dict[str, str] = sample_parser_output["dependencies"][0]
+    mocked_checksum: str = "sha256:bd2d213996ff7b3b364cd342a585fbee9797dbc1c0c6d868dc4150cc75739781"
     sample_parser_output["dependencies"] = [
         {
             "type": "git",
@@ -151,6 +152,7 @@ def test_parse_gemlock(
             "type": "rubygems",
             "source": "https://rubygems.org/",
             "platforms": ["ruby"],
+            "checksums": {"ruby": mocked_checksum},
             **base_dep,
         },
     ]
@@ -171,7 +173,12 @@ def test_parse_gemlock(
             root=str(rooted_tmp_path),
             subpath="vendor/pathgem",
         ),
-        GemDependency(name="example", version="0.1.0", source="https://rubygems.org/"),
+        GemDependency(
+            name="example",
+            version="0.1.0",
+            source="https://rubygems.org/",
+            checksum=mocked_checksum,
+        ),
     ]
 
     assert f"Package {rooted_tmp_path.path.name} is bundled with version 2.5.10" in caplog.messages
@@ -294,11 +301,13 @@ def test_parse_gemlock_detects_binaries_and_adds_to_parse_result_when_allowed_to
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     base_dep: dict[str, str] = sample_parser_output["dependencies"][0]
+    mocked_checksum: str = "sha256:bd2d213996ff7b3b364cd342a585fbee9797dbc1c0c6d868dc4150cc75739781"
     sample_parser_output["dependencies"] = [
         {
             "type": "rubygems",
             "source": "https://rubygems.org/",
             "platforms": ["i8080_cpm"],
+            "checksums": {"i8080_cpm": mocked_checksum},
             **base_dep,
         },
     ]
@@ -314,6 +323,7 @@ def test_parse_gemlock_detects_binaries_and_adds_to_parse_result_when_allowed_to
             version="0.1.0",
             source="https://rubygems.org/",
             platform="i8080_cpm",
+            checksum=mocked_checksum,
         ),
     ]
 

--- a/tests/unit/package_managers/bundler/test_parser.py
+++ b/tests/unit/package_managers/bundler/test_parser.py
@@ -162,6 +162,7 @@ def test_parse_gemlock(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     base_dep: dict[str, str] = sample_parser_output["dependencies"][0]
+    mocked_checksum: str = "sha256:bd2d213996ff7b3b364cd342a585fbee9797dbc1c0c6d868dc4150cc75739781"
     sample_parser_output["dependencies"] = [
         {
             "type": "git",
@@ -178,6 +179,7 @@ def test_parse_gemlock(
             "type": "rubygems",
             "source": "https://rubygems.org/",
             "platforms": ["ruby"],
+            "checksums": {"ruby": mocked_checksum},
             **base_dep,
         },
     ]
@@ -198,7 +200,12 @@ def test_parse_gemlock(
             root=str(rooted_tmp_path),
             subpath="vendor/pathgem",
         ),
-        GemDependency(name="example", version="0.1.0", source="https://rubygems.org/"),
+        GemDependency(
+            name="example",
+            version="0.1.0",
+            source="https://rubygems.org/",
+            checksum=mocked_checksum,
+        ),
     ]
 
     assert f"Package {rooted_tmp_path.path.name} is bundled with version 2.5.10" in caplog.messages
@@ -321,11 +328,13 @@ def test_parse_gemlock_detects_binaries_and_adds_to_parse_result_when_allowed_to
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     base_dep: dict[str, str] = sample_parser_output["dependencies"][0]
+    mocked_checksum: str = "sha256:bd2d213996ff7b3b364cd342a585fbee9797dbc1c0c6d868dc4150cc75739781"
     sample_parser_output["dependencies"] = [
         {
             "type": "rubygems",
             "source": "https://rubygems.org/",
             "platforms": ["i8080_cpm"],
+            "checksums": {"i8080_cpm": mocked_checksum},
             **base_dep,
         },
     ]
@@ -341,6 +350,7 @@ def test_parse_gemlock_detects_binaries_and_adds_to_parse_result_when_allowed_to
             version="0.1.0",
             source="https://rubygems.org/",
             platform="i8080_cpm",
+            checksum=mocked_checksum,
         ),
     ]
 


### PR DESCRIPTION

**Description:**

Closes #1652

## Summary

The `checksum` field on `GemDependency` was always `None` — the lockfile parser never populated it and it was never used for verification. This PR wires up the full checksum pipeline for RubyGems dependencies.

## Changes

**`lockfile_parser.rb`**
- Extract checksums from the `CHECKSUMS` section via `spec.source.checksum_store.to_lock(spec)`
- Emit them in `sha256:<hexdigest>` format in the JSON output

**`gem_models.py`**
- Add checksum qualifier to `GemDependency.purl` for SBOM output

**`main.py`**
- After downloading `.gem` files, verify each against its lockfile checksum using `must_match_any_checksum`
- If no checksum is present in the lockfile, log a warning and skip verification 
