### PR TITLE
refactor(pip): make PipRequirement a subclass of packaging.Requirement

### DIFF
--- a/hermeto/core/package_managers/python/pip/main.py
+++ b/hermeto/core/package_managers/python/pip/main.py
@@ -324,7 +324,7 @@ def _download_vcs_package(
     pip_deps_dir: RootedPath,
 ) -> VCSPackage:
     """Fetch a Python package from VCS (only git is supported)."""
-    git_info = extract_git_info(req.url)
+    git_info = extract_git_info(req.direct_access_url)
 
     download_to = pip_deps_dir.join_within_root(_get_external_requirement_filepath(req))
     download_to.path.parent.mkdir(exist_ok=True, parents=True)
@@ -358,7 +358,7 @@ def _download_url_package(
 
     :param trusted_hosts: if host (or host:port) is trusted, do not verify SSL
     """
-    parsed_url = urlparse.urlparse(req.url)
+    parsed_url = urlparse.urlparse(req.direct_access_url)
 
     download_to = pip_deps_dir.join_within_root(_get_external_requirement_filepath(req))
     download_to.path.parent.mkdir(exist_ok=True, parents=True)
@@ -376,7 +376,7 @@ def _download_url_package(
     else:
         insecure = False
 
-    download_binary_file(req.url, download_to.path, insecure=insecure)
+    download_binary_file(req.direct_access_url, download_to.path, insecure=insecure)
 
     hashes = req.hashes
     missing_req_file_checksum = True
@@ -393,7 +393,7 @@ def _download_url_package(
         requirement_file=str(requirements_file.file_path.subpath_from_root),
         missing_req_file_checksum=missing_req_file_checksum,
         package_type="wheel" if parsed_url.path.endswith(WHEEL_FILE_EXTENSION) else "",
-        original_url=req.url,
+        original_url=req.direct_access_url,
         checksum=req.hashes[0],
     )
     log.debug(
@@ -648,7 +648,7 @@ def _get_external_requirement_filepath(requirement: PipRequirement) -> Path:
         package = requirement.package
         hash_spec = requirement.hashes[0]
         _, _, digest = hash_spec.partition(":")
-        orig_url = urlparse.urlparse(requirement.url)
+        orig_url = urlparse.urlparse(requirement.direct_access_url)
         file_ext = ""
         for ext in ALL_FILE_EXTENSIONS:
             if orig_url.path.endswith(ext):
@@ -663,7 +663,7 @@ def _get_external_requirement_filepath(requirement: PipRequirement) -> Path:
             filepath = Path(f"{package}-{digest}{file_ext}")
 
     elif requirement.kind == "vcs":
-        git_info = extract_git_info(requirement.url)
+        git_info = extract_git_info(requirement.direct_access_url)
         repo = git_info["repo"]
         ref = git_info["ref"]
         filepath = Path(f"{repo}-gitcommit-{ref}.tar.gz")
@@ -741,7 +741,7 @@ def _replace_external_requirements(requirements_file_path: RootedPath) -> Projec
         if requirement.kind in ("url", "vcs"):
             path = _get_external_requirement_filepath(requirement)
             templated_abspath = Path("${output_dir}", "deps", "pip", path)
-            return requirement.copy(url=f"file://{templated_abspath}")
+            return requirement.update(url=f"file://{templated_abspath}")
         return None
 
     replaced = [maybe_replace(requirement) for requirement in requirements_file.requirements]

--- a/hermeto/core/package_managers/python/pip/requirements.py
+++ b/hermeto/core/package_managers/python/pip/requirements.py
@@ -231,44 +231,48 @@ class PipRequirementsFile:
         return global_options, requirement_options, " ".join(requirement)
 
 
-class PipRequirement:
+class PipRequirement(Requirement):
     """Parse a requirement and its options from a requirement line."""
 
     # Regex used to determine if a direct access requirement specifies a
     # package name, e.g. "name @ https://..."
     HAS_NAME_IN_DIRECT_ACCESS_REQUIREMENT = re.compile(r"@.+://")
 
-    def __init__(self) -> None:
+    def __init__(self, requirement_string: str) -> None:
         """Initialize a PipRequirement."""
-        # The package name after it has been processed by setuptools, e.g. "_" are replaced
-        # with "-"
-        self.package: str = ""
-        # The package name as defined in the requirement line
-        self.raw_package: str = ""
-        self.extras: set[str] = set()
-        self.version_specs: list[tuple[str, str]] = []
-        self.environment_marker: str | None = None
+        super().__init__(requirement_string)
         self.hashes: list[str] = []
         self.qualifiers: dict[str, str] = {}
-
-        self.kind: Literal["pypi", "url", "vcs"]
-        self.download_line: str = ""
-
+        self.kind: Literal["pypi", "url", "vcs"] = "pypi"
+        self.download_line: str = requirement_string
         self.options: list[str] = []
 
-        self._url: Any = None
+    @property
+    def package(self) -> str:
+        """Return the canonicalized package name."""
+        return canonicalize_name(self.name)
 
     @property
-    def url(self) -> str:
-        """Extract the URL from the download line of a VCS or URL requirement."""
-        if self._url is None:
-            if self.kind not in ("url", "vcs"):
-                raise ValueError(f"Cannot extract URL from {self.kind} requirement")
-            # package @ url ; environment_marker
-            parts = self.download_line.split()
-            self._url = parts[2]
+    def raw_package(self) -> str:
+        """Return the package name as defined in the requirement line."""
+        return self.name
 
-        return self._url
+    @property
+    def direct_access_url(self) -> str:
+        """URL for url/vcs requirements. Raises ValueError if kind is pypi."""
+        if self.url is None:
+            raise ValueError(f"Cannot extract URL from {self.kind} requirement")
+        return self.url
+
+    @property
+    def version_specs(self) -> list[tuple[str, str]]:
+        """Return version specifiers as a list of (operator, version) tuples."""
+        return [(spec.operator, spec.version) for spec in self.specifier]
+
+    @property
+    def environment_marker(self) -> str | None:
+        """Return the environment marker as a string, or None."""
+        return str(self.marker) if self.marker else None
 
     def __str__(self) -> str:
         """Return the string representation of the PipRequirement."""
@@ -278,8 +282,20 @@ class PipRequirement:
         line.extend(f"--hash={h}" for h in self.hashes)
         return " ".join(line)
 
-    def copy(self, url: str | None = None, hashes: list[str] | None = None) -> "PipRequirement":
-        """Duplicate this instance of PipRequirement.
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, PipRequirement):
+            return NotImplemented
+        return super().__eq__(other) and self.kind == other.kind
+
+    def __hash__(self) -> int:
+        return hash((super().__hash__(), self.kind))
+
+    def copy(self) -> "PipRequirement":
+        """Return an unmodified clone of this requirement."""
+        return self.update(None, None)
+
+    def update(self, url: str | None = None, hashes: list[str] | None = None) -> "PipRequirement":
+        """Return a clone of this requirement, optionally changing the URL and/or hashes.
 
         :param str url: set a new direct access URL for the requirement. If provided, the
             new requirement is always of ``url`` kind.
@@ -313,20 +329,10 @@ class PipRequirement:
                     "Removed editable option when copying the requirement %r", self.raw_package
                 )
 
-        requirement = self.__class__()
-        # Extras are incorrectly treated as part of the URL itself. If we're setting
-        # the URL, they must be skipped.
-        if not url:
-            requirement.extras = set(self.extras)
-        requirement.package = self.package
-        requirement.raw_package = self.raw_package
-        # Version specs are ignored by pip when applied to a URL, let's do the same.
-        requirement.version_specs = [] if url else list(self.version_specs)
-        requirement.environment_marker = self.environment_marker
-        requirement.hashes = list(hashes or self.hashes)
+        requirement = self.__class__(download_line)
+        requirement.hashes = list(self.hashes if hashes is None else hashes)
         requirement.qualifiers = dict(self.qualifiers)
         requirement.kind = "url" if url else self.kind
-        requirement.download_line = download_line
         requirement.options = options
 
         return requirement
@@ -343,31 +349,27 @@ class PipRequirement:
         """
         to_be_parsed = line
         qualifiers: dict[str, str] = {}
-        requirement = cls()
 
-        if not (direct_access_kind := cls._assess_direct_access_requirement(line)):
-            requirement.kind = "pypi"
-        else:
-            requirement.kind = direct_access_kind
+        direct_access_kind = cls._assess_direct_access_requirement(line)
+        if direct_access_kind:
             to_be_parsed, qualifiers = cls._adjust_direct_access_requirement(
                 to_be_parsed, cls.HAS_NAME_IN_DIRECT_ACCESS_REQUIREMENT
             )
 
         try:
-            req = Requirement(to_be_parsed)
+            requirement = cls(to_be_parsed)
         except InvalidRequirement as exc:
             # see https://github.com/pypa/setuptools/pull/2137
-            raise UnexpectedFormat(f"Unable to parse the requirement {to_be_parsed!r}: {exc}")
+            raise UnexpectedFormat(
+                f"Unable to parse the requirement {to_be_parsed!r}: {exc}"
+            ) from exc
 
         hashes, options = cls._split_hashes_from_options(options)
 
-        requirement.download_line = to_be_parsed
+        requirement.kind = direct_access_kind or "pypi"
+        if direct_access_kind and requirement.url is None:
+            raise UnexpectedFormat(f"Direct access requirement {to_be_parsed!r} has no URL")
         requirement.options = options
-        requirement.package = canonicalize_name(req.name)
-        requirement.raw_package = req.name
-        requirement.version_specs = [(spec.operator, spec.version) for spec in req.specifier]
-        requirement.extras = req.extras
-        requirement.environment_marker = str(req.marker) if req.marker else None
         requirement.hashes = hashes
         requirement.qualifiers = qualifiers
 
@@ -613,7 +615,7 @@ def validate_requirements(requirements: list[PipRequirement]) -> None:
 
         # Fail if VCS requirement uses any VCS other than git or does not have a valid ref
         elif req.kind == "vcs":
-            url = urlparse.urlparse(req.url)
+            url = urlparse.urlparse(req.direct_access_url)
 
             if not url.scheme.startswith("git"):
                 raise UnsupportedFeature(
@@ -643,7 +645,7 @@ def validate_requirements(requirements: list[PipRequirement]) -> None:
                     ),
                 )
 
-            url = urlparse.urlparse(req.url)
+            url = urlparse.urlparse(req.direct_access_url)
             if not any(url.path.endswith(ext) for ext in ALL_FILE_EXTENSIONS):
                 msg = (
                     "URL for requirement does not contain any recognized file extension: "

--- a/hermeto/core/package_managers/python/pip/requirements.py
+++ b/hermeto/core/package_managers/python/pip/requirements.py
@@ -231,44 +231,48 @@ class PipRequirementsFile:
         return global_options, requirement_options, " ".join(requirement)
 
 
-class PipRequirement:
+class PipRequirement(Requirement):
     """Parse a requirement and its options from a requirement line."""
 
     # Regex used to determine if a direct access requirement specifies a
     # package name, e.g. "name @ https://..."
     HAS_NAME_IN_DIRECT_ACCESS_REQUIREMENT = re.compile(r"@.+://")
 
-    def __init__(self) -> None:
+    def __init__(self, requirement_string: str) -> None:
         """Initialize a PipRequirement."""
-        # The package name after it has been processed by setuptools, e.g. "_" are replaced
-        # with "-"
-        self.package: str = ""
-        # The package name as defined in the requirement line
-        self.raw_package: str = ""
-        self.extras: set[str] = set()
-        self.version_specs: list[tuple[str, str]] = []
-        self.environment_marker: str | None = None
+        super().__init__(requirement_string)
         self.hashes: list[str] = []
         self.qualifiers: dict[str, str] = {}
-
         self.kind: Literal["pypi", "url", "vcs"]
-        self.download_line: str = ""
-
+        self.download_line: str = requirement_string
         self.options: list[str] = []
 
-        self._url: Any = None
+    @property
+    def package(self) -> str:
+        """Return the canonicalized package name."""
+        return canonicalize_name(self.name)
 
     @property
-    def url(self) -> str:
-        """Extract the URL from the download line of a VCS or URL requirement."""
-        if self._url is None:
-            if self.kind not in ("url", "vcs"):
-                raise ValueError(f"Cannot extract URL from {self.kind} requirement")
-            # package @ url ; environment_marker
-            parts = self.download_line.split()
-            self._url = parts[2]
+    def raw_package(self) -> str:
+        """Return the package name as defined in the requirement line."""
+        return self.name
 
-        return self._url
+    @property
+    def direct_access_url(self) -> str:
+        """URL for url/vcs requirements. Raises ValueError if kind is pypi."""
+        if self.url is None:
+            raise ValueError(f"Cannot extract URL from {self.kind} requirement")
+        return self.url
+
+    @property
+    def version_specs(self) -> list[tuple[str, str]]:
+        """Return version specifiers as a list of (operator, version) tuples."""
+        return [(spec.operator, spec.version) for spec in self.specifier]
+
+    @property
+    def environment_marker(self) -> str | None:
+        """Return the environment marker as a string, or None."""
+        return str(self.marker) if self.marker else None
 
     def __str__(self) -> str:
         """Return the string representation of the PipRequirement."""
@@ -278,8 +282,12 @@ class PipRequirement:
         line.extend(f"--hash={h}" for h in self.hashes)
         return " ".join(line)
 
-    def copy(self, url: str | None = None, hashes: list[str] | None = None) -> "PipRequirement":
-        """Duplicate this instance of PipRequirement.
+    def copy(self) -> "PipRequirement":
+        """Return an unmodified clone of this requirement."""
+        return self.update(None, None)
+
+    def update(self, url: str | None = None, hashes: list[str] | None = None) -> "PipRequirement":
+        """Return a clone of this requirement, optionally changing the URL and/or hashes.
 
         :param str url: set a new direct access URL for the requirement. If provided, the
             new requirement is always of ``url`` kind.
@@ -313,20 +321,10 @@ class PipRequirement:
                     "Removed editable option when copying the requirement %r", self.raw_package
                 )
 
-        requirement = self.__class__()
-        # Extras are incorrectly treated as part of the URL itself. If we're setting
-        # the URL, they must be skipped.
-        if not url:
-            requirement.extras = set(self.extras)
-        requirement.package = self.package
-        requirement.raw_package = self.raw_package
-        # Version specs are ignored by pip when applied to a URL, let's do the same.
-        requirement.version_specs = [] if url else list(self.version_specs)
-        requirement.environment_marker = self.environment_marker
+        requirement = self.__class__(download_line)
         requirement.hashes = list(hashes or self.hashes)
         requirement.qualifiers = dict(self.qualifiers)
         requirement.kind = "url" if url else self.kind
-        requirement.download_line = download_line
         requirement.options = options
 
         return requirement
@@ -343,31 +341,26 @@ class PipRequirement:
         """
         to_be_parsed = line
         qualifiers: dict[str, str] = {}
-        requirement = cls()
 
-        if not (direct_access_kind := cls._assess_direct_access_requirement(line)):
-            requirement.kind = "pypi"
-        else:
-            requirement.kind = direct_access_kind
+        direct_access_kind = cls._assess_direct_access_requirement(line)
+        if direct_access_kind:
             to_be_parsed, qualifiers = cls._adjust_direct_access_requirement(
                 to_be_parsed, cls.HAS_NAME_IN_DIRECT_ACCESS_REQUIREMENT
             )
 
         try:
-            req = Requirement(to_be_parsed)
+            requirement = cls(to_be_parsed)
         except InvalidRequirement as exc:
             # see https://github.com/pypa/setuptools/pull/2137
             raise UnexpectedFormat(f"Unable to parse the requirement {to_be_parsed!r}: {exc}")
 
         hashes, options = cls._split_hashes_from_options(options)
 
+        requirement.kind = direct_access_kind or "pypi"
+        if direct_access_kind and requirement.url is None:
+            raise UnexpectedFormat(f"Direct access requirement {to_be_parsed!r} has no URL")
         requirement.download_line = to_be_parsed
         requirement.options = options
-        requirement.package = canonicalize_name(req.name)
-        requirement.raw_package = req.name
-        requirement.version_specs = [(spec.operator, spec.version) for spec in req.specifier]
-        requirement.extras = req.extras
-        requirement.environment_marker = str(req.marker) if req.marker else None
         requirement.hashes = hashes
         requirement.qualifiers = qualifiers
 
@@ -613,7 +606,7 @@ def validate_requirements(requirements: list[PipRequirement]) -> None:
 
         # Fail if VCS requirement uses any VCS other than git or does not have a valid ref
         elif req.kind == "vcs":
-            url = urlparse.urlparse(req.url)
+            url = urlparse.urlparse(req.direct_access_url)
 
             if not url.scheme.startswith("git"):
                 raise UnsupportedFeature(
@@ -643,7 +636,7 @@ def validate_requirements(requirements: list[PipRequirement]) -> None:
                     ),
                 )
 
-            url = urlparse.urlparse(req.url)
+            url = urlparse.urlparse(req.direct_access_url)
             if not any(url.path.endswith(ext) for ext in ALL_FILE_EXTENSIONS):
                 msg = (
                     "URL for requirement does not contain any recognized file extension: "

--- a/tests/unit/package_managers/python/pip/test_main.py
+++ b/tests/unit/package_managers/python/pip/test_main.py
@@ -82,6 +82,7 @@ def mock_requirement(
         hashes=hashes or [],
         qualifiers=qualifiers or {},
         url=url,
+        direct_access_url=url,
     )
 
 
@@ -656,7 +657,7 @@ def test_resolve_pip_invalid_file_path(
 )
 def test_get_external_requirement_filepath(component_kind: str, url: str) -> None:
     requirement = mock.Mock(
-        kind=component_kind, url=url, package="package", hashes=["sha256:noRealHash"]
+        kind=component_kind, url=url, direct_access_url=url, package="package", hashes=["sha256:noRealHash"],
     )
     filepath = pip._get_external_requirement_filepath(requirement)
     if component_kind == "url":

--- a/tests/unit/package_managers/python/pip/test_main.py
+++ b/tests/unit/package_managers/python/pip/test_main.py
@@ -78,6 +78,7 @@ def mock_requirement(
         hashes=hashes or [],
         qualifiers=qualifiers or {},
         url=url,
+        direct_access_url=url,
     )
 
 
@@ -629,7 +630,11 @@ def test_resolve_pip_invalid_file_path(
 )
 def test_get_external_requirement_filepath(component_kind: str, url: str) -> None:
     requirement = mock.Mock(
-        kind=component_kind, url=url, package="package", hashes=["sha256:noRealHash"]
+        kind=component_kind,
+        url=url,
+        direct_access_url=url,
+        package="package",
+        hashes=["sha256:noRealHash"],
     )
     filepath = pip._get_external_requirement_filepath(requirement)
     if component_kind == "url":

--- a/tests/unit/package_managers/python/pip/test_requirements.py
+++ b/tests/unit/package_managers/python/pip/test_requirements.py
@@ -685,7 +685,7 @@ class TestPipRequirementsFile:
         for pip_requirement in pip_requirements.requirements:
             url = new_urls.get(pip_requirement.raw_package)
             hashes = new_hashes.get(pip_requirement.raw_package)
-            new_requirements.append(pip_requirement.copy(url=url, hashes=hashes))
+            new_requirements.append(pip_requirement.update(url=url, hashes=hashes))
 
         # Verify a new PipRequirementsFile can be loaded in memory and written correctly to disk.
         new_file = PipRequirementsFile.from_requirements_and_options(
@@ -987,30 +987,27 @@ class TestPipRequirementsFile:
             ),
         ),
     )
-    def test_pip_requirement_copy(
+    def test_pip_requirement_update(
         self,
         requirement_line: str,
         requirement_options: list[str],
         new_values: dict[str, str] | dict[str, list[str]],
         expected_changes: dict[str, str],
     ) -> None:
-        """Test PipRequirement.copy method."""
+        """Test PipRequirement.update method."""
         original_requirement = PipRequirement.from_line(requirement_line, requirement_options)
-        new_requirement = original_requirement.copy(**new_values)
+        new_requirement = original_requirement.update(**new_values)
 
         for attr in self.PIP_REQUIREMENT_ATTRS:
             expected_changes.setdefault(attr, getattr(original_requirement, attr))
 
         self._assert_pip_requirement(new_requirement, expected_changes)
 
-    def test_invalid_kind_for_url(self) -> None:
-        """Test extracting URL from a requirement that does not have one."""
-        requirement = PipRequirement()
-        requirement.download_line = "aiowsgi==0.7"
-        requirement.kind = "pypi"
-
-        with pytest.raises(ValueError, match="Cannot extract URL from pypi requirement"):
-            _ = requirement.url
+    def test_pypi_requirement_has_no_url(self) -> None:
+        """Test that a PyPI requirement has no URL."""
+        requirement = PipRequirement.from_line("aiowsgi==0.7", [])
+        assert requirement.kind == "pypi"
+        assert requirement.url is None
 
     def _assert_pip_requirement(self, pip_requirement: Any, expected_requirement: Any) -> None:
         for attr, default_value in self.PIP_REQUIREMENT_ATTRS.items():

--- a/tests/unit/package_managers/python/pip/test_requirements.py
+++ b/tests/unit/package_managers/python/pip/test_requirements.py
@@ -685,7 +685,7 @@ class TestPipRequirementsFile:
         for pip_requirement in pip_requirements.requirements:
             url = new_urls.get(pip_requirement.raw_package)
             hashes = new_hashes.get(pip_requirement.raw_package)
-            new_requirements.append(pip_requirement.copy(url=url, hashes=hashes))
+            new_requirements.append(pip_requirement.update(url=url, hashes=hashes))
 
         # Verify a new PipRequirementsFile can be loaded in memory and written correctly to disk.
         new_file = PipRequirementsFile.from_requirements_and_options(
@@ -987,30 +987,79 @@ class TestPipRequirementsFile:
             ),
         ),
     )
-    def test_pip_requirement_copy(
+    def test_pip_requirement_update(
         self,
         requirement_line: str,
         requirement_options: list[str],
-        new_values: dict[str, str] | dict[str, list[str]],
-        expected_changes: dict[str, str],
+        new_values: dict[str, Any],
+        expected_changes: dict[str, Any],
     ) -> None:
-        """Test PipRequirement.copy method."""
+        """Test PipRequirement.update method."""
         original_requirement = PipRequirement.from_line(requirement_line, requirement_options)
-        new_requirement = original_requirement.copy(**new_values)
+        new_requirement = original_requirement.update(**new_values)
 
         for attr in self.PIP_REQUIREMENT_ATTRS:
             expected_changes.setdefault(attr, getattr(original_requirement, attr))
 
         self._assert_pip_requirement(new_requirement, expected_changes)
 
-    def test_invalid_kind_for_url(self) -> None:
-        """Test extracting URL from a requirement that does not have one."""
-        requirement = PipRequirement()
-        requirement.download_line = "aiowsgi==0.7"
-        requirement.kind = "pypi"
+    def test_pip_requirement_update_clears_hashes(self) -> None:
+        """Test that update(hashes=[]) clears hashes."""
+        original = PipRequirement.from_line(
+            "cnr_server @ https://github.com/quay/appr/archive/58c88e49.tar.gz#egg=cnr_server",
+            ["--hash", "sha256:4fd9429bfbb796a48c0bde6bd301ff5b3cc02adb32189d912c7f55ec2e6c70c8"],
+        )
+        updated = original.update(hashes=[])
+        assert updated.hashes == []
+        assert original.hashes != []
 
-        with pytest.raises(ValueError):
-            _ = requirement.url
+    def test_pypi_requirement_has_no_url(self) -> None:
+        """Test that a PyPI requirement has no URL."""
+        requirement = PipRequirement.from_line("aiowsgi==0.7", [])
+        assert requirement.kind == "pypi"
+        assert requirement.url is None
+
+    def test_direct_access_url_raises_for_pypi(self) -> None:
+        """Test that direct_access_url raises ValueError for PyPI requirements."""
+        requirement = PipRequirement.from_line("aiowsgi==0.7", [])
+        with pytest.raises(ValueError, match="Cannot extract URL from pypi requirement"):
+            _ = requirement.direct_access_url
+
+    def test_direct_access_url_returns_url(self) -> None:
+        """Test that direct_access_url returns the URL for url/vcs requirements."""
+        url_req = PipRequirement.from_line(
+            "cnr_server @ https://github.com/quay/appr/archive/58c88e49.tar.gz", []
+        )
+        assert url_req.direct_access_url == "https://github.com/quay/appr/archive/58c88e49.tar.gz"
+
+        vcs_req = PipRequirement.from_line(
+            "git+https://github.com/quay/appr.git@58c88e49#egg=cnr_server", []
+        )
+        assert (
+            vcs_req.direct_access_url
+            == "git+https://github.com/quay/appr.git@58c88e49#egg=cnr_server"
+        )
+
+    def test_equality_considers_kind(self) -> None:
+        """Two requirements with the same fields but different kind are not equal."""
+        req_a = PipRequirement.from_line(
+            "cnr_server @ https://github.com/quay/appr/archive/58c88e49.tar.gz", []
+        )
+        req_b = PipRequirement.from_line(
+            "cnr_server @ https://github.com/quay/appr/archive/58c88e49.tar.gz", []
+        )
+        assert req_a == req_b
+
+        req_b.kind = "vcs"
+        assert req_a != req_b
+
+    def test_equal_requirements_have_equal_hashes(self) -> None:
+        """Equal PipRequirements must produce equal hashes."""
+        req_a = PipRequirement.from_line("aiowsgi==0.7", [])
+        req_b = PipRequirement.from_line("aiowsgi==0.7", [])
+
+        assert req_a == req_b
+        assert hash(req_a) == hash(req_b)
 
     def _assert_pip_requirement(self, pip_requirement: Any, expected_requirement: Any) -> None:
         for attr, default_value in self.PIP_REQUIREMENT_ATTRS.items():


### PR DESCRIPTION
PipRequirement now inherits name, extras, specifier, marker and url directly from packaging.Requirement. Backward-compatible properties are kept for package, raw_package, version_specs and environment_marker so callers outside this file need no changes.

Closes https://github.com/hermetoproject/hermeto/issues/486


Assisted-by: Claude