### PR TITLE
fix(pip): skip requirements excluded by environment markers under binary filters

### DIFF
--- a/docs/design/binary-platform-filtering.md
+++ b/docs/design/binary-platform-filtering.md
@@ -165,6 +165,12 @@ The pip backend will be updated to filter Python wheels based on user-provided p
   - For OS, linux
   - For architecture, x86_64
 
+**Environment marker evaluation**:
+- Before artifact selection, the pip backend evaluates each requirement's [PEP 508 environment marker][] against an environment synthesized *only* from the user-provided binary filters (`arch`, `os`, `py_impl`, `py_version`), never from the host — consistent with **No Runtime Platform Detection**. This is separate from, and precedes, the wheel-tag filtering described above.
+- A requirement whose marker is false for every selected filter combination is skipped entirely (no wheel and no sdist). This restores pip's own behavior for wheel-only locks (e.g. private indexes without sdists) that mark a package unavailable on an arch: instead of failing with `PackageRejected` while searching for a nonexistent wheel, Hermeto skips it. See [#1570](https://github.com/hermetoproject/hermeto/issues/1570).
+- A marker is evaluated only when every environment variable it reads is pinned by the filters; if it reads any unpinned dimension the requirement is kept (fail-open). This referenced-variable gate is used rather than relying on evaluation to fail on unpinned values, because packaging routes operators through different code paths (`x in y` runs `str.__contains__` on the literal; `<`/`>` on non-version keys are a constant `False`), so no sentinel value can signal "unknown" for every operator. Unpinnable dimensions include `platform_release`, `extra`, and `python_full_version`'s patch level (`py_version` pins only the minor). A false *keep* wastes bandwidth or surfaces as a diagnosable error; a false *skip* would silently omit a needed dependency, which is worse for a hermetic build.
+- `os` tokens live in a different string space than PEP 508 `sys_platform`: they are substring-matched against wheel platform *tags* (`macosx_*`, `manylinux*`, `win*`), so the canonical macOS token is `macosx` (not `darwin`). The marker env therefore translates each `os` token to PEP 508 values (`macosx`/`macos`/`osx`/`darwin` → `sys_platform="darwin"`, `win`/`win32`/`windows` → `win32`); an unrecognized token leaves the OS marker fields unknown (fail-open). The `platform` (regex) filter pins no marker fields at all — it matches tags directly — so markers are always kept in that mode.
+
 **Platform Matching Examples**:
 - Example 1: Prefetching for Python 3.11 on Linux
   ```json
@@ -269,4 +275,5 @@ The rpm backend will filter packages based on a user-provided architecture list,
 [prebuildify]: https://github.com/prebuild/prebuildify
 [wheelios]: https://github.com/chmeliik/wheelios
 [packaging platform tags]: https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/
+[PEP 508 environment marker]: https://peps.python.org/pep-0508/#environment-markers
 [Gem:Platform]: https://github.com/rubygems/rubygems/blob/8ad4509f95c90cf9523a82ca917b6b842fd37132/lib/rubygems/platform.rb#L10

--- a/docs/pip.md
+++ b/docs/pip.md
@@ -540,6 +540,55 @@ Prefetch wheels for specific packages and platforms:
 }
 ```
 
+#### Environment markers
+
+When a `binary` filter is set, Hermeto evaluates each requirement's [PEP 508
+environment marker][] against an environment derived from the filters — never
+from the host. Each filter pins the marker fields it fully determines:
+
+- `arch` → `platform_machine`
+- `os` → `sys_platform`, `os_name`, `platform_system` (the `os` token is
+  translated to PEP 508 values, e.g. `macosx`/`macos` → `darwin`, `win` →
+  `win32`; a token Hermeto does not recognize leaves these fields unknown)
+- `py_impl` → `implementation_name`, `platform_python_implementation`
+- `py_version` → `python_version` (the minor version only; the patch level in
+  `python_full_version` is left unknown)
+
+The `platform` (regex) filter is mutually exclusive with `arch`/`os` and pins
+**no** marker fields — it matches wheel platform tags directly — so markers are
+always kept (fail-open) in that mode.
+
+A requirement whose marker is false for **all** selected filter combinations is
+**skipped** (neither its wheel nor its sdist is fetched), because `pip install`
+would not install it on the target platform either.
+
+This matters for multi-arch locks that mark a package unavailable on
+`ppc64le`/`s390x` with wheel-only hashes (e.g. private indexes without sdists):
+without this, Hermeto would fail with `PackageRejected` trying to find a wheel
+that does not exist, instead of skipping the requirement.
+
+Markers that read a dimension the filters do not pin stay "unknown" rather than
+being guessed:
+
+- If a marker reads a dimension you did not pin (`:all:`, an omitted
+  `py_version`, or `python_full_version`'s patch level), or one Hermeto does not
+  model (`platform_release`, `extra`, …), the requirement is **kept**
+  (fail-open) and an `info` log names the dimension.
+- In source-only mode (no `binary`), markers are **not** used to skip anything
+  (there is no declared target platform).
+- With `platform` (regex) instead of `arch`/`os`, markers that depend on
+  `platform_machine`/`sys_platform` are not used to skip (kept, fail-open).
+
+For example, under `"binary": {"arch": "ppc64le", "os": "linux"}` a requirement
+pinned as:
+
+```text
+bcrypt==5.0.0 ; platform_machine != "ppc64le" and sys_platform == "linux" \
+    --hash=sha256:...
+```
+
+is skipped, because its marker is false for `ppc64le`.
+
 ### Building from source
 
 Building wheels from sdists takes a long time, but building from source gives
@@ -884,6 +933,7 @@ these steps for you.
 [discouraged]: https://setuptools.pypa.io/en/latest/userguide/quickstart.html#setuppy-discouraged
 [Hashes]: https://pip.pypa.io/en/stable/topics/secure-installs/#hash-checking-mode
 [PEP 440]: https://peps.python.org/pep-0440/#direct-references
+[PEP 508 environment marker]: https://peps.python.org/pep-0508/#environment-markers
 [PEP 517]: https://peps.python.org/pep-0517
 [PEP 518]: https://peps.python.org/pep-0518
 [PEP 621 metadata]: https://packaging.python.org/en/latest/specifications/declaring-project-metadata/

--- a/hermeto/core/binary_filters.py
+++ b/hermeto/core/binary_filters.py
@@ -7,24 +7,34 @@ from typing import Any
 from hermeto.core.models.input import BINARY_FILTER_ALL
 
 
+def parse_filter_spec(spec: str) -> set[str] | None:
+    """Parse filter specification into allowed values set.
+
+    Returns None if spec is ':all:' or contains ':all:' as any item.
+    This matches pip's behavior where any occurrence of ':all:' means accept all.
+
+    This is the single source of truth for ``:all:`` semantics; both the
+    ``BinaryPackageFilter`` subclasses (wheel/RPM filtering) and the pip marker
+    helper parse specs through it so a skip decision can never diverge from a
+    wheel-selection decision.
+    """
+    if spec == BINARY_FILTER_ALL:
+        return None
+
+    filters = {stripped_filter for item in spec.split(",") if (stripped_filter := item.strip())}
+
+    if BINARY_FILTER_ALL in filters:
+        return None
+
+    return filters
+
+
 class BinaryPackageFilter(ABC):
     """Abstract base class for binary package filtering."""
 
     def _parse_filter_spec(self, spec: str) -> set[str] | None:
-        """Parse filter specification into allowed values set.
-
-        Returns None if spec is ':all:' or contains ':all:' as any item.
-        This matches pip's behavior where any occurrence of ':all:' means accept all.
-        """
-        if spec == BINARY_FILTER_ALL:
-            return None
-
-        filters = {stripped_filter for item in spec.split(",") if (stripped_filter := item.strip())}
-
-        if BINARY_FILTER_ALL in filters:
-            return None
-
-        return filters
+        """Parse a filter spec into allowed values (see ``parse_filter_spec``)."""
+        return parse_filter_spec(spec)
 
     @abstractmethod
     def __contains__(self, item: Any) -> bool:

--- a/hermeto/core/package_managers/python/pip/main.py
+++ b/hermeto/core/package_managers/python/pip/main.py
@@ -38,6 +38,9 @@ from hermeto.core.package_managers.general import (
     extract_git_info,
     get_vcs_qualifiers,
 )
+from hermeto.core.package_managers.python.pip.markers import (
+    requirement_matches_binary_filters,
+)
 from hermeto.core.package_managers.python.pip.package_distributions import (
     DistributionPackageInfo,
     process_package_distributions,
@@ -471,7 +474,8 @@ def _download_dependencies(
 
     :param output_dir: the root output directory for this request
     :param requirements_file: A requirements.txt file
-    :param binary_filters: process wheels?
+    :param binary_filters: target platform filters; when set, requirements whose
+        environment marker excludes the target platform are skipped (issue #1570)
     :return: list of PipPackage instances for each downloaded package
     """
     options: dict[str, Any] = process_requirements_options(requirements_file.options)
@@ -499,6 +503,25 @@ def _download_dependencies(
     pypi_reqs: list[PipRequirement] = []
     for req in requirements_file.requirements:
         log.info("-- Processing requirement line '%s'", req.download_line)
+        # A binary filter declares a target platform; a requirement whose PEP 508
+        # marker excludes that platform would never be installed by pip, so skip
+        # it rather than fail trying to resolve a wheel/sdist that does not exist.
+        # This deliberately runs *after* the whole-file hash and requirement
+        # validation above (not before): validation is a security control, so a
+        # skipped line with a missing/invalid hash must still be rejected rather
+        # than quietly bypassed. The extra strictness (a would-be-skipped line
+        # still needs a valid hash) is fail-closed and rare -- pip-compile hashes
+        # everything -- and is preferred over relaxing a security check.
+        # https://github.com/hermetoproject/hermeto/issues/1570
+        if binary_filters is not None and not requirement_matches_binary_filters(
+            req, binary_filters
+        ):
+            log.info(
+                "-- Skipping requirement excluded by its environment marker under the "
+                "binary filters: '%s'",
+                req.download_line,
+            )
+            continue
         if req.kind == "pypi":
             pypi_reqs.append(req)
             continue

--- a/hermeto/core/package_managers/python/pip/markers.py
+++ b/hermeto/core/package_managers/python/pip/markers.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Evaluate PEP 508 environment markers against user-supplied binary filters.
+
+When a ``binary`` filter declares a target platform (arch/os/python), a
+requirement whose environment marker excludes that platform (for example
+``platform_machine != "ppc64le"``) would never be installed by pip. Hermeto must
+therefore skip it instead of trying to resolve an artifact that does not exist,
+which otherwise fails with ``PackageRejected`` for wheel-only locks that carry no
+matching sdist hash.
+
+See https://github.com/hermetoproject/hermeto/issues/1570
+
+Approach: a marker is evaluated only when every environment variable it reads is
+pinned by the filters; if it reads any dimension the filters do not pin, the
+requirement is kept (fail-open). This "referenced-key" gate is deliberate rather
+than relying on marker evaluation to fail on unpinned values: packaging routes
+different operators through different code paths (e.g. ``x in y`` runs
+``str.__contains__`` on the literal, and ``<`` / ``>`` on non-version keys are a
+constant ``False``), so a sentinel value cannot reliably signal "unknown" for
+every operator.
+
+Design constraints:
+
+* No runtime platform detection. The evaluation environment is built solely from
+  the user's filters. ``packaging.markers.Marker.evaluate`` merges the supplied
+  environment *over* ``default_environment()`` (the real host), so every
+  ``default_environment()`` key must be present; unpinned keys use a poison value
+  (never a host value).
+
+* Fail open. For a hermetic build tool a false *skip* is the worst outcome (a
+  silent ``ModuleNotFoundError`` at image build time), whereas a false *keep* is
+  either wasted bandwidth or a loud, diagnosable ``PackageRejected``.
+"""
+
+import logging
+from collections.abc import Iterator
+from itertools import product
+
+from packaging.markers import InvalidMarker, Marker, Variable, default_environment
+
+from hermeto.core.binary_filters import parse_filter_spec
+from hermeto.core.models.input import PipBinaryFilters
+from hermeto.core.package_managers.python.pip.requirements import PipRequirement
+
+log = logging.getLogger(__name__)
+
+# The set of environment keys packaging expects is fixed; capture it once so env
+# construction never re-invokes host detection and there is no per-requirement
+# cost. Only the key *names* are used -- every value is overwritten with a pin or
+# a poison, so no host value ever leaks.
+_DEFAULT_ENV_KEYS = tuple(default_environment())
+
+
+# Hermeto ``os`` filter tokens mapped to the marker fields a pinned OS fully
+# determines. ``os`` tokens are substring-matched against wheel platform *tags*
+# elsewhere (a different string space: a linux target matches "manylinux"/"linux"
+# tags, macOS matches "macosx" tags, Windows matches "win"), so they must be
+# translated here rather than used verbatim as ``sys_platform``. The canonical
+# tokens are the ones the docs use ("linux", "macosx"); the rest are accepted
+# aliases. Tokens absent from this map leave these fields unpinned (fail-open
+# keep) -- so being permissive here only ever makes marker evaluation more precise
+# for whatever token the user actually passed.
+_DARWIN_FIELDS = {"sys_platform": "darwin", "os_name": "posix", "platform_system": "Darwin"}
+_WINDOWS_FIELDS = {"sys_platform": "win32", "os_name": "nt", "platform_system": "Windows"}
+_OS_TO_MARKER_FIELDS = {
+    "linux": {"sys_platform": "linux", "os_name": "posix", "platform_system": "Linux"},
+    "macosx": _DARWIN_FIELDS,  # the documented macOS token; matches "macosx_*" tags
+    "macos": _DARWIN_FIELDS,
+    "osx": _DARWIN_FIELDS,
+    "darwin": _DARWIN_FIELDS,
+    "windows": _WINDOWS_FIELDS,
+    "win32": _WINDOWS_FIELDS,
+    "win": _WINDOWS_FIELDS,
+}
+
+# Hermeto ``py_impl`` filter tokens mapped to the marker fields they determine.
+# Tokens absent from this map (e.g. the generic "py") leave these fields unpinned
+# rather than guessing an implementation the user did not declare.
+_PY_IMPL_TO_MARKER = {
+    "cp": {"implementation_name": "cpython", "platform_python_implementation": "CPython"},
+    "pp": {"implementation_name": "pypy", "platform_python_implementation": "PyPy"},
+}
+
+
+class _UncontrolledEnvKey(Exception):
+    """Raised if a poison value is ever compared during evaluation.
+
+    With the referenced-key gate this should not happen for a well-formed marker,
+    so it is a defensive backstop: it still causes a fail-open keep and names the
+    offending key.
+    """
+
+    def __init__(self, key: str) -> None:
+        self.key = key
+        super().__init__(key)
+
+
+class _Poison(str):
+    """A ``str`` subclass filling env keys the filters do not pin.
+
+    It must subclass ``str``: ``Marker.evaluate`` unconditionally calls
+    ``env["python_full_version"].endswith("+")`` before evaluating anything, so a
+    non-``str`` value here would raise ``AttributeError``. The buffer is the empty
+    string so that any comparison packaging *does* route through these overrides
+    (the referenced-key gate should prevent that, but this is defense in depth)
+    raises rather than silently comparing. Interpretability of a leaked poison is
+    preserved via ``__repr__``/``__str__`` rather than the compared value.
+    """
+
+    _key: str
+
+    def __new__(cls, key: str) -> "_Poison":
+        obj = str.__new__(cls, "")
+        obj._key = key
+        return obj
+
+    def __repr__(self) -> str:
+        return f"_Poison({self._key!r})"
+
+    def __str__(self) -> str:
+        return f"POISON:{self._key}"
+
+    def __eq__(self, other: object) -> bool:
+        raise _UncontrolledEnvKey(self._key)
+
+    def __ne__(self, other: object) -> bool:
+        raise _UncontrolledEnvKey(self._key)
+
+    def __lt__(self, other: object) -> bool:
+        raise _UncontrolledEnvKey(self._key)
+
+    def __le__(self, other: object) -> bool:
+        raise _UncontrolledEnvKey(self._key)
+
+    def __gt__(self, other: object) -> bool:
+        raise _UncontrolledEnvKey(self._key)
+
+    def __ge__(self, other: object) -> bool:
+        raise _UncontrolledEnvKey(self._key)
+
+    def __contains__(self, other: object) -> bool:
+        raise _UncontrolledEnvKey(self._key)
+
+    __hash__ = None  # type: ignore[assignment]
+
+
+def _concrete_groups(
+    filters: PipBinaryFilters,
+) -> tuple[list[list[dict[str, str]]], dict[str, str]]:
+    """Translate filters into concrete marker-env values.
+
+    Returns ``(groups, base)`` where ``base`` holds env values that apply to every
+    combination and ``groups`` is a list of dimensions to take the product over;
+    each dimension is a list of mutually-exclusive partial env dicts (its OR
+    values). Correlated fields (a single OS pins sys_platform + os_name +
+    platform_system together) are kept in one partial dict so the product never
+    mixes e.g. sys_platform="linux" with platform_system="Darwin".
+
+    A dimension is included only when the filters fully determine it; otherwise
+    its keys are left out (and stay poison / uncontrolled -> fail-open).
+    """
+    groups: list[list[dict[str, str]]] = []
+
+    # platform (regex) mode is mutually exclusive with arch/os and does not
+    # translate to platform_machine/sys_platform, so those stay unpinned.
+    if filters.platform is None:
+        arches = parse_filter_spec(filters.arch)
+        if arches is not None:
+            groups.append([{"platform_machine": arch} for arch in sorted(arches)])
+
+        oses = parse_filter_spec(filters.os)
+        if oses is not None and all(os_token in _OS_TO_MARKER_FIELDS for os_token in oses):
+            groups.append([dict(_OS_TO_MARKER_FIELDS[os_token]) for os_token in sorted(oses)])
+
+    impls = parse_filter_spec(filters.py_impl)
+    if impls is not None and all(impl in _PY_IMPL_TO_MARKER for impl in impls):
+        groups.append([dict(_PY_IMPL_TO_MARKER[impl]) for impl in sorted(impls)])
+
+    base: dict[str, str] = {}
+    if filters.py_version is not None:
+        # Hermeto packs the version as an int (312 -> 3.12); divmod handles a
+        # two-digit major correctly where string slicing would not. py_version
+        # pins only the minor version -- python_full_version (the patch level) is
+        # intentionally left unpinned, so markers like python_full_version >=
+        # "3.12.1" fail open instead of being decided by a synthesized ".0".
+        major, minor = divmod(filters.py_version, 100)
+        base["python_version"] = f"{major}.{minor}"
+
+    return groups, base
+
+
+def _controlled_keys(filters: PipBinaryFilters) -> set[str]:
+    """Return the set of marker env keys the filters pin to concrete values."""
+    groups, base = _concrete_groups(filters)
+    keys = set(base)
+    for group in groups:
+        for option in group:
+            keys.update(option)
+    return keys
+
+
+def _iter_filter_envs(filters: PipBinaryFilters) -> Iterator[dict[str, str]]:
+    """Yield one marker environment per concrete combination of pinned filters.
+
+    Every ``default_environment()`` key is present in each env: pinned keys get
+    concrete strings, the rest stay ``_Poison`` (never host values).
+    """
+    groups, base = _concrete_groups(filters)
+    for combo in product(*groups) if groups else [()]:
+        env: dict[str, str] = {key: _Poison(key) for key in _DEFAULT_ENV_KEYS}
+        env.update(base)
+        for partial in combo:
+            env.update(partial)
+        yield env
+
+
+def _marker_variables(marker: Marker) -> set[str]:
+    """Return the set of environment variable names a marker reads.
+
+    Walks packaging's parsed marker structure (a nested list of
+    ``(Variable|Value, Op, Value|Variable)`` tuples joined by "and"/"or"). Only
+    ``Variable`` nodes are environment keys; ``Value`` nodes are string literals.
+    """
+    names: set[str] = set()
+
+    def _walk(node: object) -> None:
+        if isinstance(node, list):
+            for child in node:
+                _walk(child)
+        elif isinstance(node, tuple):
+            lhs, _op, rhs = node
+            for side in (lhs, rhs):
+                if isinstance(side, Variable):
+                    names.add(side.value)
+
+    _walk(marker._markers)
+    return names
+
+
+def requirement_matches_binary_filters(
+    requirement: PipRequirement,
+    filters: PipBinaryFilters,
+) -> bool:
+    """Return whether a requirement should be fetched under these binary filters.
+
+    ``True`` means keep/fetch, ``False`` means skip. A requirement is skipped only
+    when its environment marker evaluates false for *every* concrete filter
+    combination. If the marker reads any dimension the filters do not pin, the
+    result is ambiguous and the requirement is kept (fail-open).
+
+    The caller must only invoke this when ``filters`` describes a target platform;
+    skipping is not applied in source-only mode.
+    """
+    marker_str = requirement.environment_marker
+    if not marker_str:
+        return True
+
+    # ``from_line`` already parsed and re-serialized the marker, so re-parsing
+    # here (which keeps this helper independent of the PipRequirement internals)
+    # should not fail -- but if packaging ever rejects it, fail open rather than
+    # aborting the whole fetch, honoring the fail-open contract.
+    try:
+        marker = Marker(marker_str)
+    except InvalidMarker:
+        log.info(
+            "Keeping %r: its environment marker %r could not be parsed (fail-open)",
+            requirement.download_line,
+            marker_str,
+        )
+        return True
+
+    uncontrolled = _marker_variables(marker) - _controlled_keys(filters)
+    if uncontrolled:
+        log.info(
+            "Keeping %r: its environment marker reads %s, which the binary filters "
+            "do not pin (fail-open)",
+            requirement.download_line,
+            ", ".join(repr(key) for key in sorted(uncontrolled)),
+        )
+        return True
+
+    for env in _iter_filter_envs(filters):
+        try:
+            # context="requirement" avoids injecting extra="" the way the default
+            # metadata context does; combined with the gate above, evaluation only
+            # touches pinned, concrete values.
+            if marker.evaluate(env, context="requirement"):
+                return True
+        except Exception:
+            # Defensive: the gate should make evaluation total, so any error here
+            # is unexpected -- fail open rather than risk a wrong skip.
+            log.debug(
+                "Keeping %r: could not evaluate its environment marker (fail-open)",
+                requirement.download_line,
+                exc_info=True,
+            )
+            return True
+
+    return False

--- a/tests/integration/pip/scenarios/pip_binary_marker_skip_excluded_arch/in/pyproject.toml
+++ b/tests/integration/pip/scenarios/pip_binary_marker_skip_excluded_arch/in/pyproject.toml
@@ -1,0 +1,4 @@
+[project]
+name = "package"
+version = "0.1.0"
+dependencies = ["bcrypt==5.0.0"]

--- a/tests/integration/pip/scenarios/pip_binary_marker_skip_excluded_arch/in/requirements.txt
+++ b/tests/integration/pip/scenarios/pip_binary_marker_skip_excluded_arch/in/requirements.txt
@@ -1,0 +1,6 @@
+# Reproducer for https://github.com/hermetoproject/hermeto/issues/1570
+# bcrypt has a wheel-only lock and a marker excluding ppc64le/s390x. Under a
+# binary filter targeting ppc64le, hermeto must skip it (pip would never install
+# it) instead of failing with PackageRejected trying to find a ppc64le wheel.
+bcrypt==5.0.0 ; implementation_name == "cpython" and platform_machine != "ppc64le" and platform_machine != "s390x" and sys_platform == "linux" \
+    --hash=sha256:81e5dab254e44e82bee49bca4e593b21b7e70a48bcf15725d6588df387098e54

--- a/tests/integration/pip/test_pip.py
+++ b/tests/integration/pip/test_pip.py
@@ -85,6 +85,23 @@ SCENARIOS_DIR = Path(__file__).parent / "scenarios"
             ),
             id="pip_no_sdists",
         ),
+        # A wheel-only requirement whose marker excludes the target arch must be
+        # skipped, not rejected -- this asserts the end-to-end run succeeds (exit 0,
+        # no PackageRejected) and logs the skip. That the skipped artifact is never
+        # downloaded is asserted deterministically at the unit level in
+        # test_main.py::TestDownloadDependenciesMarkerSkip (a skipped requirement
+        # never reaches the resolver/downloader), which needs no network.
+        # https://github.com/hermetoproject/hermeto/issues/1570
+        pytest.param(
+            utils.TestParameters(
+                packages=(
+                    {"path": ".", "type": "pip", "binary": {"arch": "ppc64le", "os": "linux"}},
+                ),
+                check_output=False,
+                expected_output="Skipping requirement excluded by its environment marker",
+            ),
+            id="pip_binary_marker_skip_excluded_arch",
+        ),
         pytest.param(
             utils.TestParameters(
                 packages=({"path": ".", "type": "pip", "binary": {}},),

--- a/tests/unit/package_managers/python/pip/test_main.py
+++ b/tests/unit/package_managers/python/pip/test_main.py
@@ -22,8 +22,13 @@ from hermeto.core.errors import (
     UnrecognizedFileExtension,
     UnsupportedFeature,
 )
+from hermeto.core.models.input import PipBinaryFilters
 from hermeto.core.package_managers.python.pip import main as pip
 from hermeto.core.package_managers.python.pip.packages import PipPackageInfo, URLPackage, VCSPackage
+from hermeto.core.package_managers.python.pip.requirements import (
+    PipRequirement,
+    PipRequirementsFile,
+)
 from hermeto.core.rooted_path import RootedPath
 from tests.common_utils import GIT_REF
 
@@ -985,3 +990,102 @@ class TestPipIndexUrlEnv:
 
         with pytest.raises(InvalidInput):
             pip._download_dependencies(rooted_tmp_path, req_file)
+
+
+class TestDownloadDependenciesMarkerSkip:
+    """_download_dependencies skips marker-excluded requirements under binary filters.
+
+    Regression guard for the wiring in the download loop, complementing the pure
+    helper tests in test_markers.py.
+    https://github.com/hermetoproject/hermeto/issues/1570
+    """
+
+    DIGEST = "sha256:" + "0" * 64
+
+    @pytest.mark.parametrize(
+        "arch, bcrypt_expected",
+        [
+            pytest.param("ppc64le", False, id="excluded_arch_skips_bcrypt"),
+            pytest.param("x86_64", True, id="included_arch_keeps_bcrypt"),
+        ],
+    )
+    @mock.patch("hermeto.core.package_managers.python.pip.main._resolve_and_download_pypi_packages")
+    def test_pypi_marker_excluded_never_reaches_resolve(
+        self,
+        mock_resolve: Any,
+        arch: str,
+        bcrypt_expected: bool,
+        rooted_tmp_path: RootedPath,
+    ) -> None:
+        mock_resolve.return_value = []
+        marker = 'platform_machine != "ppc64le" and platform_machine != "s390x"'
+        bcrypt = PipRequirement.from_line(f"bcrypt==5.0.0 ; {marker}", ["--hash", self.DIGEST])
+        sibling = PipRequirement.from_line("click==8.0.0", ["--hash", self.DIGEST])
+        req_file = PipRequirementsFile.from_requirements_and_options([bcrypt, sibling], [])
+
+        pip._download_dependencies(
+            rooted_tmp_path, req_file, PipBinaryFilters(arch=arch, os="linux")
+        )
+
+        resolved_names = {req.package for req in mock_resolve.call_args[0][0]}
+        # The unmarked sibling is always resolved; bcrypt only when the arch matches.
+        assert "click" in resolved_names
+        assert ("bcrypt" in resolved_names) is bcrypt_expected
+
+    @pytest.mark.parametrize(
+        "arch, expected_downloaded",
+        [
+            pytest.param("ppc64le", False, id="excluded_arch_skips_url"),
+            pytest.param("s390x", True, id="included_arch_downloads_url"),
+        ],
+    )
+    @mock.patch("hermeto.core.package_managers.python.pip.main._download_url_package")
+    def test_url_marker_gates_download(
+        self,
+        mock_download_url: Any,
+        arch: str,
+        expected_downloaded: bool,
+        rooted_tmp_path: RootedPath,
+    ) -> None:
+        # The keep path matters as much as the skip path: a regression that dropped
+        # every non-pypi requirement would still pass a skip-only assertion.
+        mock_download_url.return_value = None
+        url_req = PipRequirement.from_line(
+            'foo @ https://example.com/foo-1.0.tar.gz ; platform_machine == "s390x"',
+            ["--hash", self.DIGEST],
+        )
+        req_file = PipRequirementsFile.from_requirements_and_options([url_req], [])
+
+        pip._download_dependencies(
+            rooted_tmp_path, req_file, PipBinaryFilters(arch=arch, os="linux")
+        )
+
+        assert mock_download_url.called is expected_downloaded
+
+    @pytest.mark.parametrize(
+        "arch, expected_downloaded",
+        [
+            pytest.param("ppc64le", False, id="excluded_arch_skips_vcs"),
+            pytest.param("s390x", True, id="included_arch_downloads_vcs"),
+        ],
+    )
+    @mock.patch("hermeto.core.package_managers.python.pip.main._download_vcs_package")
+    def test_vcs_marker_gates_download(
+        self,
+        mock_download_vcs: Any,
+        arch: str,
+        expected_downloaded: bool,
+        rooted_tmp_path: RootedPath,
+    ) -> None:
+        mock_download_vcs.return_value = mock.Mock()
+        vcs_req = PipRequirement.from_line(
+            f'bar @ git+https://github.com/org/repo@{GIT_REF} ; platform_machine == "s390x"',
+            [],
+        )
+        req_file = PipRequirementsFile.from_requirements_and_options([vcs_req], [])
+
+        pip._download_dependencies(
+            rooted_tmp_path, req_file, PipBinaryFilters(arch=arch, os="linux")
+        )
+
+        assert mock_download_vcs.called is expected_downloaded

--- a/tests/unit/package_managers/python/pip/test_markers.py
+++ b/tests/unit/package_managers/python/pip/test_markers.py
@@ -1,0 +1,517 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Tests for PEP 508 marker evaluation under binary filters.
+
+See https://github.com/hermetoproject/hermeto/issues/1570
+
+These tests deliberately drive the real ``packaging.markers.Marker.evaluate`` via
+real ``PipRequirement.from_line`` and ``PipBinaryFilters`` instances -- the whole
+point of #1570 is a subtle interaction with packaging internals, which a mocked
+evaluator would hide.
+"""
+
+import logging
+
+import pytest
+from packaging.markers import default_environment
+
+from hermeto.core.models.input import PipBinaryFilters
+from hermeto.core.package_managers.python.pip.markers import (
+    _iter_filter_envs,
+    _marker_variables,
+    _Poison,
+    _UncontrolledEnvKey,
+    requirement_matches_binary_filters,
+)
+from hermeto.core.package_managers.python.pip.requirements import PipRequirement
+
+# A real git commit-shaped ref (40 hex chars) so VCS requirements parse.
+GIT_REF = "a" * 40
+
+# The literal marker from the #1570 issue body.
+BCRYPT_1570_MARKER = (
+    'implementation_name == "cpython" '
+    'and platform_machine != "ppc64le" '
+    'and platform_machine != "s390x" '
+    'and sys_platform == "linux"'
+)
+
+
+def _pypi_req(
+    marker: str | None = None, name: str = "bcrypt", version: str = "5.0.0"
+) -> PipRequirement:
+    line = f"{name}=={version}"
+    if marker:
+        line += f" ; {marker}"
+    return PipRequirement.from_line(line, [])
+
+
+def _url_req(marker: str | None = None) -> PipRequirement:
+    line = "foo @ https://example.com/foo-1.0.tar.gz"
+    if marker:
+        line += f" ; {marker}"
+    return PipRequirement.from_line(line, [])
+
+
+def _vcs_req(marker: str | None = None) -> PipRequirement:
+    line = f"foo @ git+https://github.com/org/repo@{GIT_REF}"
+    if marker:
+        line += f" ; {marker}"
+    return PipRequirement.from_line(line, [])
+
+
+class TestFlagship:
+    """The #1570 case must skip, and must not crash on packaging's version repair.
+
+    These two are the first line of defense: they fail loudly if the poison is
+    ever changed to a plain object (AttributeError on ``.endswith``) or to a
+    non-empty string (silent ``False`` on version markers).
+    """
+
+    def test_issue_1570_bcrypt_is_skipped_on_ppc64le(self) -> None:
+        req = _pypi_req(BCRYPT_1570_MARKER)
+        filters = PipBinaryFilters(arch="ppc64le", os="linux")  # note: no py_version
+
+        assert requirement_matches_binary_filters(req, filters) is False
+
+    def test_poison_survives_python_full_version_repair(self) -> None:
+        # py_version unset -> python_full_version stays poisoned. packaging calls
+        # python_full_version.endswith("+") before evaluating; this must not raise.
+        req = _pypi_req('platform_machine != "ppc64le"')
+        filters = PipBinaryFilters(arch="ppc64le", os="linux")
+
+        result = requirement_matches_binary_filters(req, filters)
+
+        assert isinstance(result, bool)
+        assert result is False
+
+
+@pytest.mark.parametrize(
+    "req, filters, expected",
+    [
+        pytest.param(
+            _pypi_req(),
+            PipBinaryFilters(arch="ppc64le", os="linux"),
+            True,
+            id="no_marker_keeps",
+        ),
+        pytest.param(
+            _pypi_req('platform_machine != "ppc64le" and sys_platform == "linux"'),
+            PipBinaryFilters(arch="ppc64le", os="linux"),
+            False,
+            id="exclude_ppc_on_ppc_skips",
+        ),
+        pytest.param(
+            _pypi_req('platform_machine != "ppc64le" and sys_platform == "linux"'),
+            PipBinaryFilters(arch="x86_64", os="linux"),
+            True,
+            id="exclude_ppc_on_x86_keeps",
+        ),
+        pytest.param(
+            _pypi_req('platform_machine != "ppc64le"'),
+            PipBinaryFilters(arch="x86_64,ppc64le", os="linux"),
+            True,
+            id="multi_arch_or_keeps_if_any_matches",
+        ),
+        pytest.param(
+            _pypi_req('platform_machine != "ppc64le"'),
+            PipBinaryFilters(arch=":all:", os="linux"),
+            True,
+            id="all_arch_keeps_fail_open",
+        ),
+        pytest.param(
+            _pypi_req('python_version < "3.11"'),
+            PipBinaryFilters(arch="x86_64", os="linux", py_version=312),
+            False,
+            id="py_version_pinned_excludes",
+        ),
+        pytest.param(
+            _pypi_req('python_version >= "3.12"'),
+            PipBinaryFilters(arch="x86_64", os="linux"),
+            True,
+            id="py_version_unset_fails_open",
+        ),
+        pytest.param(
+            _pypi_req('sys_platform == "linux"'),
+            PipBinaryFilters(arch="x86_64", os="linux"),
+            True,
+            id="only_linux_on_linux_keeps",
+        ),
+        pytest.param(
+            _pypi_req('sys_platform == "linux"'),
+            PipBinaryFilters(arch="x86_64", os="macos"),
+            False,
+            id="only_linux_on_macos_skips",
+        ),
+        pytest.param(
+            # os="darwin" must map to sys_platform "darwin", not the literal token.
+            _pypi_req('sys_platform != "darwin"'),
+            PipBinaryFilters(arch="x86_64", os="darwin"),
+            False,
+            id="os_darwin_maps_to_sys_platform_darwin",
+        ),
+        pytest.param(
+            # "macosx" is the documented macOS token; it must map to sys_platform
+            # "darwin" too, so a linux-only marker is skipped when targeting macOS.
+            _pypi_req('sys_platform == "linux"'),
+            PipBinaryFilters(arch="x86_64", os="macosx"),
+            False,
+            id="os_macosx_maps_to_sys_platform_darwin_skip",
+        ),
+        pytest.param(
+            _pypi_req('sys_platform == "darwin"'),
+            PipBinaryFilters(arch="x86_64", os="macosx"),
+            True,
+            id="os_macosx_matches_darwin_marker_keep",
+        ),
+        pytest.param(
+            # A mixed linux,macosx target still fully determines the OS dimension
+            # (both tokens are known), so an os-only marker evaluates concretely.
+            _pypi_req('sys_platform == "win32"'),
+            PipBinaryFilters(arch="x86_64", os="linux,macosx"),
+            False,
+            id="os_linux_macosx_both_known_skips_win_marker",
+        ),
+        pytest.param(
+            _pypi_req('platform_release == "5.10"'),
+            PipBinaryFilters(arch="x86_64", os="linux"),
+            True,
+            id="uncontrolled_key_fails_open",
+        ),
+        pytest.param(
+            # extra is never pinned; must fail open, not evaluate against "".
+            _pypi_req('platform_machine != "ppc64le" and extra == "test"'),
+            PipBinaryFilters(arch="ppc64le", os="linux"),
+            True,
+            id="extra_marker_fails_open",
+        ),
+        pytest.param(
+            _pypi_req('"y" in platform_release'),
+            PipBinaryFilters(arch="x86_64", os="linux"),
+            True,
+            id="in_operator_on_poison_fails_open",
+        ),
+        pytest.param(
+            _pypi_req('"y" not in platform_release'),
+            PipBinaryFilters(arch="x86_64", os="linux"),
+            True,
+            id="not_in_operator_on_poison_fails_open",
+        ),
+        pytest.param(
+            _url_req('platform_machine == "s390x"'),
+            PipBinaryFilters(arch="ppc64le", os="linux"),
+            False,
+            id="url_requirement_marker_skips",
+        ),
+        pytest.param(
+            _vcs_req('platform_machine == "s390x"'),
+            PipBinaryFilters(arch="ppc64le", os="linux"),
+            False,
+            id="vcs_requirement_marker_skips",
+        ),
+        pytest.param(
+            # platform regex mode must not synthesize platform_machine/sys_platform.
+            _pypi_req('platform_machine == "s390x"'),
+            PipBinaryFilters(platform="ppc64le"),
+            True,
+            id="platform_regex_mode_fails_open",
+        ),
+        pytest.param(
+            # py_impl default is cp -> implementation_name is cpython.
+            _pypi_req('implementation_name == "pypy"'),
+            PipBinaryFilters(arch="x86_64", os="linux"),
+            False,
+            id="py_impl_cp_excludes_pypy_marker",
+        ),
+        pytest.param(
+            # ":all:" appearing among other values means unconstrained.
+            _pypi_req('platform_machine != "ppc64le"'),
+            PipBinaryFilters(arch="x86_64,:all:", os="linux"),
+            True,
+            id="all_among_values_keeps_fail_open",
+        ),
+        pytest.param(
+            # A py_impl token with no known marker mapping stays poisoned.
+            _pypi_req('implementation_name == "cpython"'),
+            PipBinaryFilters(arch="x86_64", os="linux", py_impl="py"),
+            True,
+            id="unknown_py_impl_fails_open",
+        ),
+        pytest.param(
+            # An os token with no known sys_platform mapping stays poisoned.
+            _pypi_req('sys_platform == "linux"'),
+            PipBinaryFilters(arch="x86_64", os="haiku"),
+            True,
+            id="unknown_os_fails_open",
+        ),
+        # Membership with the variable on the LEFT: the value being searched for is
+        # unpinned, so this must fail open rather than be decided by substring.
+        pytest.param(
+            _pypi_req('platform_machine not in "x86_64"'),
+            PipBinaryFilters(arch=":all:", os="linux"),
+            True,
+            id="membership_var_on_left_unpinned_fails_open",
+        ),
+        pytest.param(
+            _pypi_req('platform_machine in "x86_64,aarch64"'),
+            PipBinaryFilters(arch=":all:", os="linux"),
+            True,
+            id="membership_in_var_on_left_unpinned_fails_open",
+        ),
+        # py_version pins only the minor; a same-minor patch comparison is unknown.
+        pytest.param(
+            _pypi_req('python_full_version >= "3.12.1"'),
+            PipBinaryFilters(arch="x86_64", os="linux", py_version=312),
+            True,
+            id="python_full_version_patch_fails_open",
+        ),
+        # A pinned os also determines os_name and platform_system.
+        pytest.param(
+            _pypi_req('os_name != "posix"'),
+            PipBinaryFilters(arch="x86_64", os="linux"),
+            False,
+            id="pinned_os_determines_os_name_skip",
+        ),
+        pytest.param(
+            _pypi_req('platform_system == "Linux"'),
+            PipBinaryFilters(arch="x86_64", os="linux"),
+            True,
+            id="pinned_os_determines_platform_system_keep",
+        ),
+        pytest.param(
+            _pypi_req('os_name == "nt"'),
+            PipBinaryFilters(arch="x86_64", os="windows"),
+            True,
+            id="pinned_windows_determines_os_name_keep",
+        ),
+        # Nested boolean trees: an unpinned key anywhere in the tree fails open,
+        # regardless of the surrounding and/or structure (verifies the gate walks
+        # the whole marker, not just top-level clauses).
+        pytest.param(
+            _pypi_req('platform_machine == "ppc64le" and platform_release == "5"'),
+            PipBinaryFilters(arch="ppc64le", os="linux"),
+            True,
+            id="nested_controlled_and_poison_fails_open",
+        ),
+        pytest.param(
+            _pypi_req('platform_release == "5" or platform_machine == "ppc64le"'),
+            PipBinaryFilters(arch="ppc64le", os="linux"),
+            True,
+            id="nested_poison_or_controlled_fails_open",
+        ),
+        # Fully-controlled nested trees are evaluated concretely.
+        pytest.param(
+            _pypi_req(
+                '(platform_machine == "ppc64le" or platform_machine == "s390x") '
+                'and sys_platform == "linux"'
+            ),
+            PipBinaryFilters(arch="x86_64", os="linux"),
+            False,
+            id="fully_controlled_nested_skips",
+        ),
+        pytest.param(
+            _pypi_req(
+                '(platform_machine == "x86_64" or platform_machine == "s390x") '
+                'and sys_platform == "linux"'
+            ),
+            PipBinaryFilters(arch="x86_64", os="linux"),
+            True,
+            id="fully_controlled_nested_keeps",
+        ),
+        # PEP 440 wildcard on a pinned python_version.
+        pytest.param(
+            _pypi_req('python_version == "3.11.*"'),
+            PipBinaryFilters(arch="x86_64", os="linux", py_version=311),
+            True,
+            id="wildcard_python_version_matches",
+        ),
+        pytest.param(
+            _pypi_req('python_version == "3.11.*"'),
+            PipBinaryFilters(arch="x86_64", os="linux", py_version=312),
+            False,
+            id="wildcard_python_version_excludes",
+        ),
+        # PEP 508 string comparisons are case-sensitive; the env uses the real
+        # lowercase sys_platform, so "Linux" does not match (as pip would decide).
+        pytest.param(
+            _pypi_req('sys_platform == "Linux"'),
+            PipBinaryFilters(arch="x86_64", os="linux"),
+            False,
+            id="sys_platform_comparison_is_case_sensitive",
+        ),
+    ],
+)
+def test_requirement_matches_binary_filters(
+    req: PipRequirement, filters: PipBinaryFilters, expected: bool
+) -> None:
+    assert requirement_matches_binary_filters(req, filters) is expected
+
+
+@pytest.mark.parametrize("py_version", [0, 207, 400, -1, 31299])
+def test_unusual_py_version_values_return_bool_without_crashing(py_version: int) -> None:
+    """py_version is an unvalidated int; odd values (Python 2.x, 4.x, 0, negative,
+    packed-too-large) must not crash the helper -- they yield a bool (fail-open on
+    any resulting version-parse error)."""
+    req = _pypi_req('python_version >= "3.0"')
+    result = requirement_matches_binary_filters(
+        req, PipBinaryFilters(arch="x86_64", os="linux", py_version=py_version)
+    )
+    assert isinstance(result, bool)
+
+
+def test_large_marker_is_handled_efficiently() -> None:
+    """Marker size does not drive the env product (env count = filter cardinality),
+    so even a pathologically long marker is handled in linear time."""
+    marker = " or ".join(f'platform_machine == "arch{i}"' for i in range(500))
+    result = requirement_matches_binary_filters(
+        _pypi_req(marker), PipBinaryFilters(arch="x86_64", os="linux")
+    )
+    assert result is False
+
+
+class TestFailOpenLogging:
+    def test_uncontrolled_key_logs_info_naming_the_key(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        req = _pypi_req('platform_release == "5.10"')
+        filters = PipBinaryFilters(arch="x86_64", os="linux")
+
+        with caplog.at_level(logging.INFO):
+            assert requirement_matches_binary_filters(req, filters) is True
+
+        assert "platform_release" in caplog.text
+
+    def test_extra_marker_logs_info_naming_extra(self, caplog: pytest.LogCaptureFixture) -> None:
+        req = _pypi_req('extra == "test"')
+        filters = PipBinaryFilters(arch="x86_64", os="linux")
+
+        with caplog.at_level(logging.INFO):
+            assert requirement_matches_binary_filters(req, filters) is True
+
+        assert "extra" in caplog.text
+
+    def test_unexpected_evaluate_error_fails_open_at_debug(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Defensive branch: any error other than an unpinned-dimension access must
+        # still fail open (keep), logged at debug rather than info.
+        def boom(*args: object, **kwargs: object) -> bool:
+            raise ValueError("unexpected packaging failure")
+
+        monkeypatch.setattr(
+            "hermeto.core.package_managers.python.pip.markers.Marker.evaluate", boom
+        )
+        req = _pypi_req('platform_machine != "ppc64le"')
+        filters = PipBinaryFilters(arch="ppc64le", os="linux")
+
+        with caplog.at_level(logging.DEBUG):
+            assert requirement_matches_binary_filters(req, filters) is True
+
+        assert any(record.levelno == logging.DEBUG for record in caplog.records)
+
+    def test_unparsable_marker_fails_open_at_info(
+        self, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The re-parse should never fail (from_line already parsed it), but if
+        # packaging ever rejects the marker it must fail open, not abort the fetch.
+        from packaging.markers import InvalidMarker
+
+        def boom(*args: object, **kwargs: object) -> object:
+            raise InvalidMarker("synthetic parse failure")
+
+        monkeypatch.setattr("hermeto.core.package_managers.python.pip.markers.Marker", boom)
+        req = _pypi_req('platform_machine != "ppc64le"')
+        filters = PipBinaryFilters(arch="ppc64le", os="linux")
+
+        with caplog.at_level(logging.INFO):
+            assert requirement_matches_binary_filters(req, filters) is True
+
+        assert "could not be parsed" in caplog.text
+
+
+class TestMarkerVariables:
+    """Guards the (acknowledged) private ``marker._markers`` walk against silent
+    breakage on a packaging upgrade -- if the structure changes, these fail loudly
+    rather than the gate quietly reading no variables and mis-skipping."""
+
+    def test_extracts_all_referenced_keys_both_operand_orders(self) -> None:
+        from packaging.markers import Marker
+
+        marker = Marker(
+            'platform_machine != "ppc64le" and (sys_platform == "linux" or "x" in platform_release)'
+        )
+
+        assert _marker_variables(marker) == {
+            "platform_machine",
+            "sys_platform",
+            "platform_release",
+        }
+
+    def test_ignores_string_literals(self) -> None:
+        from packaging.markers import Marker
+
+        # Only the variable is an env key; both quoted operands are literals.
+        assert _marker_variables(Marker('"linux" == sys_platform')) == {"sys_platform"}
+
+
+class TestCompleteEnvInvariant:
+    """Every synthesized env must cover all default_environment() keys as str.
+
+    A missing key would leak the host value into evaluation (violating "no
+    runtime platform detection"); a non-str value would crash packaging's
+    unconditional python_full_version repair.
+    """
+
+    @pytest.mark.parametrize(
+        "filters",
+        [
+            PipBinaryFilters(arch="ppc64le", os="linux"),
+            PipBinaryFilters(arch="x86_64,aarch64", os="linux,macos", py_version=312),
+            PipBinaryFilters(arch=":all:", os=":all:", py_impl=":all:"),
+            PipBinaryFilters(platform="ppc64le"),
+        ],
+    )
+    def test_env_covers_all_default_keys_as_str(self, filters: PipBinaryFilters) -> None:
+        expected_keys = set(default_environment())
+
+        envs = list(_iter_filter_envs(filters))
+
+        assert envs, "at least one env combination must be produced"
+        for env in envs:
+            assert set(env) == expected_keys
+            assert all(isinstance(value, str) for value in env.values())
+
+    def test_unpinned_dimensions_are_poison(self) -> None:
+        # arch pinned, os/py unpinned -> platform_machine concrete, others poison.
+        (env,) = list(_iter_filter_envs(PipBinaryFilters(arch="ppc64le", os=":all:")))
+
+        assert env["platform_machine"] == "ppc64le"
+        assert isinstance(env["python_full_version"], _Poison)
+        assert isinstance(env["sys_platform"], _Poison)
+
+
+class TestPoison:
+    def test_buffer_is_empty_but_labels_are_interpretable(self) -> None:
+        poison = _Poison("python_version")
+
+        assert len(poison) == 0  # empty buffer is load-bearing for fail-open
+        assert str(poison) == "POISON:python_version"
+        assert repr(poison) == "_Poison('python_version')"
+
+    @pytest.mark.parametrize("op", ["eq", "ne", "lt", "le", "gt", "ge"])
+    def test_comparisons_raise(self, op: str) -> None:
+        import operator
+
+        poison = _Poison("platform_machine")
+        with pytest.raises(_UncontrolledEnvKey) as exc_info:
+            getattr(operator, op)(poison, "x86_64")
+        assert exc_info.value.key == "platform_machine"
+
+    def test_membership_raises(self) -> None:
+        poison = _Poison("platform_release")
+        with pytest.raises(_UncontrolledEnvKey) as exc_info:
+            "x" in poison
+        assert exc_info.value.key == "platform_release"
+
+    def test_is_unhashable(self) -> None:
+        with pytest.raises(TypeError):
+            hash(_Poison("platform_machine"))


### PR DESCRIPTION
Closes https://github.com/hermetoproject/hermeto/issues/1570

## Problem

When a pip `binary` filter declares a target platform (`arch`/`os`/`py_impl`/`py_version`), Hermeto never consults a requirement's PEP 508 environment marker. A requirement whose marker excludes the target — e.g. `platform_machine != "ppc64le"` — is resolved anyway, even though `pip install` would simply skip it.

For a **wheel-only lock with no sdist hash** this is fatal: `WheelsFilter` finds no matching wheel, the sdist fallback is filtered out by checksum (or no sdist exists at all), and Hermeto fails with `PackageRejected: No distributions found`.

This is the real-world AIPCC case from the issue thread: the binary index [deliberately ships no sdists](https://packages.redhat.com/domains/public-rhai/distributions), and the lock uses markers to declare per-arch availability. As the thread notes, a `pip-compile --generate-hashes` lock that also records the sdist hash already succeeds via the existing sdist fallback — **this PR does not change that path**. It fixes only the wheel-only case, where there is nothing valid to fall back to and the marker already says "not for this platform."

## Fix

Add `requirement_matches_binary_filters` (`pip/markers.py`) and consult it in `_download_dependencies` before any wheel/sdist resolution, for pypi, url and vcs kinds alike. When a binary filter is set and a requirement's marker is false for every selected filter combination, the requirement is skipped. Source-only mode (no `binary`) is unchanged.

The marker is evaluated against an environment **synthesized only from the user's filters, never the host** (honoring *No Runtime Platform Detection*). Each filter pins the marker fields it fully determines:

- `arch` → `platform_machine`
- `os` → `sys_platform`, `os_name`, `platform_system` (tokens are translated to PEP 508 values — the documented `macosx` token maps to `sys_platform` `darwin`, not the literal token)
- `py_impl` → `implementation_name`, `platform_python_implementation`
- `py_version` → `python_version` (minor only; the `python_full_version` patch level stays unknown)

**Referenced-key gate + fail-open.** A marker is evaluated only when every variable it reads is pinned by the filters; if it reads any unpinned dimension (`:all:`, an unset `py_version`, `platform` regex mode, or an unmodeled key such as `platform_release`), the requirement is kept. This gate is used rather than relying on evaluation to fail on unpinned values, because `packaging` routes operators through different code paths (`x in y` runs `str.__contains__` on the literal; `<`/`>` on non-version keys are a constant `False`), so no sentinel value can signal "unknown" for every operator.

Fail-open is deliberate: a false *skip* silently omits a needed dependency (the worst outcome for a hermetic build — a late `ModuleNotFoundError` at image-build time), whereas a false *keep* is wasted bandwidth or a loud, diagnosable `PackageRejected`.

## Scope / limitations

- Active only when a `binary` filter is set; source-only mode never skips on markers.
- `platform` (regex) mode pins no marker fields (it matches wheel tags directly) → always fail-open.
- Hash and requirement validation still run over the whole file **before** the skip, so a skipped line with a missing/invalid hash is still rejected — deliberate, since validation is a security control.

## Testing

- New `tests/unit/package_managers/python/pip/test_markers.py` drives the real `packaging.markers.Marker.evaluate` through real `PipRequirement.from_line` / `PipBinaryFilters` (flagship: the issue's bcrypt marker under `arch=ppc64le` is skipped). `markers.py` is at 100% line coverage.
- Download-loop regression in `test_main.py` proves a marker-excluded requirement never reaches the resolver/downloader — keep **and** skip paths, for pypi/url/vcs.
- Integration scenario `pip_binary_marker_skip_excluded_arch` mirrors `pip_no_sdists` but asserts success + a skip log (runs under `nox -s integration-tests`).
- Docs: `docs/pip.md` (user-facing) and `docs/design/binary-platform-filtering.md` (rationale).
- Locally: full unit suite (`1463 passed, 7 skipped`) and `ruff check` / `ruff format --check` / `mypy` all green.

## Ethos fit

- **Accurate prefetch/SBOM** — does not fetch (or fail fetching) artifacts that would never be installed on the target platform.
- **No arbitrary code execution** — pure `packaging.markers` evaluation; no resolver invocation.
- **Checksum validation** — unchanged for fetched packages; skipped lines never enter download.
- **Reproducibility** — the decision depends only on the committed markers and the request's `binary` filters, never on the host.

## AI assistance

This contribution is AI-assisted, disclosed via `Assisted-by:` trailers on every commit alongside the DCO `Signed-off-by`, per the AI Contribution Policy. The human contributor has reviewed and understands every line and is accountable for the submission.
