### PR TITLE
.github: gating: Add the 'merge_group' even trigger to the workflow

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
     inputs: {}
 


### PR DESCRIPTION
Apparently the following [1]:

    'You must use the merge_group event to trigger your GitHub Actions
    workflow when a pull request is added to a merge queue.'

means that if you use "Require status checks to pass" as well as "Require merge queues" on your github project the CI will be stuck on waiting for required checks in the merge queue unless `merge_group` trigger is configured for a workflow. IOW checks are not skipped in the merge queue, they are again required to run (even if they just had passed, allowing one to actually put a PR to the queue), thanks GitHub...

[1] https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#configuring-continuous-integration-ci-workflows-for-merge-queues