### PR TITLE
chore(linter): Ignore missing docstrings in __init__()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ ignore = [
     "D100",  # missing docstring in public module
     "D104",  # missing docstring in public package
     "D105",  # missing docstring in magic method
+    "D107",  # missing docstring in __init__
     "E501",  # line too long
     "E731",  # do not assign a lambda expression
     "S404",  # import subprocess


### PR DESCRIPTION
A growing number of classes contain initializer methods with dosctrings following the pattern of """Initializing Foo.""". Such docstrings do not add value to the codebase (what an initializer is for is a common knowledge), but cannot be removed because the linter would complain otherwise. This change instructs the linter to ignore missing docstrings in __init__()s.