### PR TITLE
Remove dead code, fix subtle bugs, and clean up stale leftovers

### DIFF
--- a/hermeto/core/checksum.py
+++ b/hermeto/core/checksum.py
@@ -23,18 +23,6 @@ class ChecksumInfo(NamedTuple):
     algorithm: str
     hexdigest: str
 
-    def to_sri(self) -> str:
-        """Return the Subresource Integrity representation of this ChecksumInfo.
-
-        https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
-
-        Note: npm and Yarn classic (v1) use this format in their lockfiles; newer Yarn
-        versions use a different integrity representation that does not go through this helper.
-        """
-        bytes_sha = bytes.fromhex(self.hexdigest)
-        base64_sha = base64.b64encode(bytes_sha).decode("utf-8")
-        return f"{self.algorithm}-{base64_sha}"
-
     def __str__(self) -> str:
         return f"{self.algorithm}:{self.hexdigest}"
 

--- a/hermeto/core/errors.py
+++ b/hermeto/core/errors.py
@@ -300,12 +300,10 @@ class MissingChecksum(InvalidChecksum):
         """
         if element is None:
             reason = "Checksum is missing"
-            checksum_value = ""
         else:
             reason = f"{element!r} is missing mandatory integrity checksum."
-            checksum_value = element
 
-        super().__init__(checksum=checksum_value, reason=reason, solution=solution)
+        super().__init__(checksum="", reason=reason, solution=solution)
 
     default_solution = "Please check that the checksum exists"
 

--- a/hermeto/core/models/input.py
+++ b/hermeto/core/models/input.py
@@ -16,7 +16,7 @@ from hermeto.core.rooted_path import PathOutsideRoot, RootedPath
 BINARY_FILTER_ALL = ":all:"
 
 if TYPE_CHECKING:
-    from pydantic.error_wrappers import ErrorDict
+    from pydantic_core import ErrorDetails
 
 
 log = logging.getLogger(__name__)
@@ -77,7 +77,7 @@ def _present_user_input_error(validation_error: pydantic.ValidationError) -> str
     errors = validation_error.errors()
     n_errors = len(errors)
 
-    def show_error(error: "ErrorDict") -> str:
+    def show_error(error: "ErrorDetails") -> str:
         location = " -> ".join(map(str, error["loc"]))
         if error.get("type") != "union_tag_invalid":
             message = error["msg"]

--- a/hermeto/core/models/input.py
+++ b/hermeto/core/models/input.py
@@ -91,7 +91,7 @@ def _present_user_input_error(validation_error: pydantic.ValidationError) -> str
             quoted = ", ".join(f"'{t}'" for t in sorted(expected))
             message = f"Requested backend type '{ctx.get('tag', '<unknown>')}' doesn't match expected ones: {quoted}"
 
-        if location != "__root__":
+        if location:
             message = f"{location}\n  {message}"
 
         return message
@@ -153,10 +153,8 @@ class SSLOptions(pydantic.BaseModel, extra="forbid"):
 
         if not Path(val).is_file():
             raise ValueError(
-                (
-                    f"Specified ssl auth file '{info.field_name}':'{val}' is not a regular file.",
-                    "Make sure the file exists and that it has correct permissions.",
-                )
+                f"Specified ssl auth file '{info.field_name}':'{val}' is not a regular file."
+                " Make sure the file exists and that it has correct permissions."
             )
 
         return val

--- a/hermeto/core/models/output.py
+++ b/hermeto/core/models/output.py
@@ -59,7 +59,7 @@ class EnvironmentVariable(pydantic.BaseModel, frozen=True):
         log.debug(f"Resolving environment variable '{self.name}={self.value}'")
         ret = self.value
         substituted: set[str] = set()
-        for i, m in enumerate(mappings):
+        for i, _ in enumerate(mappings):
             log.debug(f"EnvironmentVariable resolution iteration {i + 1}.: {ret}")
 
             t_old = string.Template(ret)

--- a/hermeto/core/models/sbom.py
+++ b/hermeto/core/models/sbom.py
@@ -162,7 +162,7 @@ class Pedigree(pydantic.BaseModel):
     patches: list[Patch]
 
 
-FOUND_BY_APP_PROPERTY: Property = Property(name=PropertyEnum.PROP_FOUND_BY, value=f"{APP_NAME}")
+FOUND_BY_APP_PROPERTY = Property(name=PropertyEnum.PROP_FOUND_BY, value=APP_NAME)
 
 
 class Component(pydantic.BaseModel):
@@ -226,7 +226,7 @@ class Tool(pydantic.BaseModel):
 class Metadata(pydantic.BaseModel):
     """Metadata field in a SBOM."""
 
-    tools: list[Tool] = [Tool(vendor="red hat", name=f"{APP_NAME}")]
+    tools: list[Tool] = [Tool(vendor="red hat", name=APP_NAME)]
 
 
 def spdx_now() -> datetime:

--- a/hermeto/core/package_managers/cargo/main.py
+++ b/hermeto/core/package_managers/cargo/main.py
@@ -532,8 +532,10 @@ def _sanitize_cargo_config(config_content: str) -> str:
 def _temporary_cwd(path_to_new_cwd: Path) -> Generator[None, None, None]:
     oldcwd = os.getcwd()
     os.chdir(path_to_new_cwd)
-    yield
-    os.chdir(oldcwd)
+    try:
+        yield
+    finally:
+        os.chdir(oldcwd)
 
 
 def _run_cmd_watching_out_for_lock_mismatch(

--- a/hermeto/core/package_managers/cargo/main.py
+++ b/hermeto/core/package_managers/cargo/main.py
@@ -442,8 +442,7 @@ def _sanitized_cargo_config_file(package_dir: RootedPath) -> Generator[None, Non
         yield
     finally:
         for config, data in configs_contents:
-            if data is not None:
-                config.path.write_text(data)
+            config.path.write_text(data)
 
 
 def _make_basic_token_from_proxy_credential(cargo_config: CargoSettings) -> str:
@@ -573,8 +572,7 @@ def _run_cmd_watching_out_for_lock_mismatch(
                 log.warning(warn_about_imminent_update_to_cargo_lock)
                 with _temporary_cwd(package_dir):
                     # Extract env from params if present to pass to cargo generate-lockfile
-                    env = params.get("env", {})
-                    update_cmd_params = {"env": env} if env else {}
+                    update_cmd_params = {"env": params.get("env", {})}
                     run_cmd(cmd=update_cargo_lock_cmd, params=update_cmd_params)
                 # If it fails here then something else is horribly broken.
                 # No more attempts to salvage the situation will be made.

--- a/hermeto/core/package_managers/generic/models.py
+++ b/hermeto/core/package_managers/generic/models.py
@@ -121,14 +121,11 @@ class LockfileArtifactAuth(BaseModel):
     bearer: BearerAuth | None = None
     model_config = ConfigDict(extra="forbid")
 
-    @model_validator(mode="before")
-    @classmethod
-    def _check_mutually_exclusive(cls, values: dict) -> dict:
-        if ("basic" not in values and "bearer" not in values) or (
-            "basic" in values and "bearer" in values
-        ):
+    @model_validator(mode="after")
+    def _check_mutually_exclusive(self) -> "LockfileArtifactAuth":
+        if (self.basic is None) == (self.bearer is None):
             raise ValueError("Exactly one of the auth types must be set")
-        return values
+        return self
 
     def get_headers(self) -> dict[str, str]:
         """Return the headers for the artifact."""

--- a/hermeto/core/package_managers/gomod/go.py
+++ b/hermeto/core/package_managers/gomod/go.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 import tempfile
 from collections import UserDict
-from collections.abc import Iterable
+from collections.abc import Collection
 from functools import cache, cached_property, total_ordering
 from pathlib import Path
 from typing import Any, Sequence
@@ -202,7 +202,7 @@ class Go:
         # references below:
         # [1] https://github.com/golang/go/issues/26520
         # [2] https://golang.org/cl/34385
-        with tempfile.TemporaryDirectory(prefix=f"{APP_NAME}", suffix="go-download") as td:
+        with tempfile.TemporaryDirectory(prefix=APP_NAME, suffix="go-download") as td:
             log.debug("Installing Go %s toolchain shim from '%s'", release, url)
             env = {
                 "PATH": os.environ.get("PATH", ""),
@@ -271,6 +271,8 @@ class Go:
                 f"Go execution failed: {APP_NAME} re-tried running `{' '.join(cmd)}` command "
                 f"{n_tries} times."
             )
+            # run_cmd already logs stderr; the caught error only summarizes it,
+            # so `from None` avoids a redundant chained duplicate.
             raise PackageManagerError(err_msg) from None
 
     @staticmethod
@@ -396,12 +398,12 @@ def _get_gomod_version(go_mod_file: RootedPath) -> tuple[str | None, str | None]
     return (go_version, toolchain_version)
 
 
-def _select_toolchain(go_mod_file: RootedPath, installed_toolchains: Iterable[Go]) -> Go | None:
+def _select_toolchain(go_mod_file: RootedPath, installed_toolchains: Collection[Go]) -> Go | None:
     """
     Pick the closest matching installed toolchain give a go.mod file.
 
     :param go_mod_file: path to an application go.mod file as RootedPath
-    :param installed_toolchains: an iterable of Go instances pointing to actual Go binaries
+    :param installed_toolchains: a collection of Go instances pointing to actual Go binaries
     :return: a Go instance which matches the go.mod version constraints or None if we could not find
              a satisfying toolchain version installed
     """
@@ -468,7 +470,12 @@ def _select_toolchain(go_mod_file: RootedPath, installed_toolchains: Iterable[Go
                 work_toolchain = first(installed_toolchains)
                 go = Go.from_missing_toolchain(release_str, work_toolchain.binary)
                 log.debug("Using Go toolchain version '%s'", go.version)
-            except Exception as ex:
+            except (
+                PackageManagerError,
+                OSError,
+                subprocess.CalledProcessError,
+                subprocess.TimeoutExpired,
+            ) as ex:
                 log.error("Failed to download a Go toolchain version '%s': '%s'", release_str, ex)
                 return None
     return go
@@ -507,9 +514,7 @@ def _list_installed_toolchains() -> set[Go]:
         try:
             log.debug("Probing %s toolchain...", bin_path)
             ret.add(Go(binary=bin_path.as_posix()))
-        except Exception as e:
-            # Logging toolchain probing failures due to [1].
-            # [1] https://bandit.readthedocs.io/en/1.8.3/plugins/b112_try_except_continue.html
+        except (PackageManagerError, OSError, subprocess.CalledProcessError) as e:
             log.debug("Toolchain %s failed probing: %s, skipping...", bin_path, e)
 
     log.debug(

--- a/hermeto/core/package_managers/gomod/main.py
+++ b/hermeto/core/package_managers/gomod/main.py
@@ -78,8 +78,6 @@ class ParsedOrigin(_ParsedModel):
     vcs: str
     url: str
     hash: str
-    tag_sum: str | None = None
-    ref: str | None = None
 
 
 class ParsedModule(_ParsedModel):
@@ -387,7 +385,7 @@ def _create_packages_from_parsed_data(
 
         relative_path = _resolve_package_relative_path(package, module)
 
-        return Package(relative_path=str(relative_path), module=module)
+        return Package(relative_path=relative_path, module=module)
 
     def _find_parent_module_by_name(package: ParsedPackage) -> Module:
         """Return the longest module name that is contained in package's import_path."""
@@ -682,7 +680,7 @@ def _disable_telemetry(go: Go, run_params: dict[str, Any]) -> None:
 
 
 def _go_list_deps(
-    go: Go, pattern: Literal["./...", "all"], run_params: dict[str, Any] | None = None
+    go: Go, pattern: Literal["./...", "all"], run_params: dict[str, Any]
 ) -> Iterator[ParsedPackage]:
     """Run go list -deps -json and return the parsed list of packages.
 
@@ -691,7 +689,7 @@ def _go_list_deps(
     The "all" pattern includes dependencies needed only for tests. Use it to get a more
     complete module list (roughly matching the list of downloaded modules).
     """
-    cmd = ["list", "-e", "-deps", "-json=ImportPath,Module,Standard,Deps", pattern]
+    cmd = ["list", "-e", "-deps", "-json=ImportPath,Module,Standard", pattern]
     return map(
         ParsedPackage.model_validate,
         load_json_stream(go(cmd, run_params)),
@@ -1360,14 +1358,10 @@ class ModuleVersionResolver:
 
 
 def _validate_local_replacements(modules: Iterable[ParsedModule], app_path: RootedPath) -> None:
-    replaced_paths = [
-        (module.path, module.replace.path)
-        for module in modules
-        if module.replace and module.replace.path.startswith(".")
-    ]
-
-    for _, path in replaced_paths:
-        app_path.join_within_root(path)
+    """Check that local replacements point to paths within app_path."""
+    for module in modules:
+        if module.replace and module.replace.path.startswith("."):
+            app_path.join_within_root(module.replace.path)
 
 
 def _parse_vendor(context_dir: RootedPath) -> Iterable[ParsedModule]:

--- a/hermeto/core/package_managers/gomod/main.py
+++ b/hermeto/core/package_managers/gomod/main.py
@@ -1164,7 +1164,9 @@ class ModuleVersionResolver:
         module_major_version = int(match.group("major_version")) if match else None
 
         # If no match, prefer v1.x.x tags but fallback to v0.x.x tags if both are present
-        major_versions_to_try = (module_major_version,) if module_major_version else (1, 0)
+        major_versions_to_try = (
+            (module_major_version,) if module_major_version is not None else (1, 0)
+        )
 
         if app_dir.path == app_dir.root:
             subpath = None
@@ -1314,7 +1316,8 @@ class ModuleVersionResolver:
         if tag is None:
             # If the major version isn't in the import path and there is not a versioned commit with the
             # version of 1, the major version defaults to 0.
-            return f"v{module_major_version or '0'}.0.0-{commit_timestamp}-{commit_hash}"
+            major = module_major_version if module_major_version is not None else 0
+            return f"v{major}.0.0-{commit_timestamp}-{commit_hash}"
 
         tag_semantic_version = self._get_semantic_version_from_tag(tag.name, subpath)
 
@@ -1514,12 +1517,19 @@ def prepare_netrc_contents() -> str:
         password {secret}"""
 
 
+def _write_file_with_mode(path: Path, content: str, mode: int) -> None:
+    """Write content to a file with explicit permissions, bypassing umask."""
+    old_mask = os.umask(0)
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, mode)
+        with open(fd, "w") as f:
+            f.write(content)
+    finally:
+        os.umask(old_mask)
+
+
 def inject_netrc(netrc_stuff: str, temp_netrc_dir: Path) -> str:
     """Inject a temporary .netrc."""
     netrc = temp_netrc_dir / ".netrc"
-    old_mask = os.umask(0)
-    netrc_fd = os.open(path=netrc, flags=(os.O_WRONLY | os.O_CREAT | os.O_TRUNC), mode=0o600)
-    with open(netrc_fd, "w") as f:
-        f.write(netrc_stuff)
-    os.umask(old_mask)
+    _write_file_with_mode(netrc, netrc_stuff, 0o600)
     return str(netrc)

--- a/hermeto/core/package_managers/javascript/npm/resolver.py
+++ b/hermeto/core/package_managers/javascript/npm/resolver.py
@@ -96,9 +96,9 @@ def _get_npm_dependencies(
         dep_type = classify_resolved_url(url)
         proxy_auth = None
 
-        if dep_type == "file":
-            continue
-        elif dep_type == "git":
+        # dep_type is "git", "registry", or "https". "file" deps are filtered
+        # upstream by get_dependencies_to_download() and never reach here.
+        if dep_type == "git":
             download_paths[url] = clone_repo_pack_archive(parse_git_clone_url(url), download_dir)
         else:
             if dep_type == "registry":

--- a/hermeto/core/package_managers/javascript/yarn/project.py
+++ b/hermeto/core/package_managers/javascript/yarn/project.py
@@ -10,7 +10,7 @@ import logging
 import re
 from collections import UserDict
 from pathlib import Path
-from typing import Any, Literal, NamedTuple, TypedDict
+from typing import Any, NamedTuple, TypedDict
 
 import semver
 import yaml
@@ -21,11 +21,6 @@ from hermeto.core.package_managers.javascript.package_json import PackageJson
 from hermeto.core.rooted_path import RootedPath
 
 log = logging.getLogger(__name__)
-
-
-ChecksumBehavior = Literal["throw", "update", "ignore"]
-PnpMode = Literal["strict", "loose"]
-NodeLinker = Literal["pnp", "pnpm", "node-modules"]
 
 
 class Plugin(TypedDict):

--- a/hermeto/core/package_managers/javascript/yarn/resolver.py
+++ b/hermeto/core/package_managers/javascript/yarn/resolver.py
@@ -11,7 +11,6 @@ import logging
 import re
 import zipfile
 from collections import defaultdict
-from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
@@ -258,7 +257,7 @@ def create_components(
             package_mapping[package.parsed_locator] = package
 
     component_resolver = _ComponentResolver(
-        package_mapping, dev_locators, patch_locators, project, output_dir, tarball_vcs_url_map
+        dev_locators, patch_locators, project, output_dir, tarball_vcs_url_map
     )
     return [component_resolver.get_component(package) for package in package_mapping.values()]
 
@@ -286,7 +285,6 @@ class _CouldNotResolve(ValueError):
 class _ComponentResolver:
     def __init__(
         self,
-        package_mapping: Mapping[Locator, Package],
         dev_raw_locators: set[str],
         patch_locators: list[PatchLocator],
         project: Project,
@@ -296,7 +294,6 @@ class _ComponentResolver:
         """Initialize the component resolver."""
         self._project = project
         self._output_dir = output_dir
-        self._package_mapping = package_mapping
         self._dev_raw_locators = dev_raw_locators
         self._tarball_vcs_url_map = tarball_vcs_url_map or {}
         self._pedigree_mapping = self._get_pedigree_mapping(patch_locators)

--- a/hermeto/core/package_managers/javascript/yarn_classic/project.py
+++ b/hermeto/core/package_managers/javascript/yarn_classic/project.py
@@ -20,7 +20,6 @@ from hermeto.core.rooted_path import RootedPath
 class YarnLock:
     """A yarn.lock file."""
 
-    path: RootedPath
     data: dict[str, Any]
     yarn_lockfile: lockfile.Lockfile
 
@@ -50,7 +49,7 @@ class YarnLock:
                 solution="Please verify the content of the file.",
             )
 
-        return cls(path, yarn_lockfile.data, yarn_lockfile)
+        return cls(yarn_lockfile.data, yarn_lockfile)
 
 
 @dataclass(frozen=True)

--- a/hermeto/core/package_managers/python/pip/package_distributions.py
+++ b/hermeto/core/package_managers/python/pip/package_distributions.py
@@ -212,9 +212,6 @@ def process_package_distributions(
     filtered_wheels: list[DistributionPackageInfo] = []
 
     for package in to_process:
-        if package.package_type is None or package.package_type not in allowed_distros:
-            continue
-
         pypi_checksums: set[ChecksumInfo] = {
             ChecksumInfo(algorithm, digest) for algorithm, digest in package.digests.items()
         }
@@ -367,11 +364,14 @@ class WheelsFilter(BinaryPackageFilter):
         return self.abi is None or abi in ("abi3", "none") or any(a in abi for a in self.abi)
 
     def _compatible_tag_interpreter(self, interpreter: str, abi: str) -> bool:
-        compatible_py_impl = (
+        is_compatible_py_impl = (
             self.py_impl is None
             or "py3" in interpreter
             or any(impl in interpreter for impl in self.py_impl)
         )
+
+        if self.py_version is None:
+            return is_compatible_py_impl
 
         wheel_py_versions = _parse_py_versions(interpreter)
 
@@ -390,9 +390,7 @@ class WheelsFilter(BinaryPackageFilter):
             is_compatible_candidate(v, this) for v in wheel_py_versions
         )
 
-        compatible_py_version = self.py_version is None or some_candidate_is_compatible
-
-        return compatible_py_impl and compatible_py_version
+        return is_compatible_py_impl and some_candidate_is_compatible
 
 
 def _parse_py_versions(interpreter: str) -> list[int]:

--- a/hermeto/core/package_managers/rpm/main.py
+++ b/hermeto/core/package_managers/rpm/main.py
@@ -400,7 +400,7 @@ def _verify_downloaded(metadata: dict[Path, Any]) -> None:
 
         # checksum is optional
         if file_metadata["checksum"] is not None:
-            alg, digest = file_metadata["checksum"].split(":")
+            alg, digest = file_metadata["checksum"].split(":", 1)
             method = getattr(hashlib, alg.lower(), None)
             if method is not None:
                 h = method(usedforsecurity=False)
@@ -431,8 +431,8 @@ def _generate_sbom_components(
             continue
         package = Package.from_filepath(file_path, file_metadata)
         component = package.to_component(lockfile_path)
-        if include_summary_in_sbom:
-            summary = Property(name=f"{APP_NAME}:rpm_summary", value=str(package.summary))
+        if include_summary_in_sbom and package.summary:
+            summary = Property(name=f"{APP_NAME}:rpm_summary", value=package.summary)
             component.properties.append(summary)
         components.append(component)
     return components

--- a/hermeto/core/package_managers/rpm/main.py
+++ b/hermeto/core/package_managers/rpm/main.py
@@ -70,9 +70,7 @@ class Package:
             # Red Hat PURL RPM guideline suggests injecting 'src' into the arch qualifier for SRPMS
             kwargs["arch"] = "src"
 
-        kwargs["repository_id"] = (
-            repoid if repoid and not repoid.startswith(f"{APP_NAME}") else None
-        )
+        kwargs["repository_id"] = repoid if repoid and not repoid.startswith(APP_NAME) else None
         kwargs["download_url"] = rpm_download_metadata["url"]
         kwargs["checksum"] = rpm_download_metadata.get("checksum")
 
@@ -169,7 +167,7 @@ class Package:
 
         if self.modularity_label:
             properties.append(
-                Property(name=f"{APP_NAME}:rpm_modularity_label", value=str(self.modularity_label))
+                Property(name=f"{APP_NAME}:rpm_modularity_label", value=self.modularity_label)
             )
 
         return Component(
@@ -481,11 +479,9 @@ def _generate_repofiles(
     in the project file.
     """
     dnf_options = None
-    dnf_options_repos = None
 
     if options:
         dnf_options = options.get("rpm", {}).get("dnf", {})
-        dnf_options_repos = dnf_options.keys()
 
     package_dir = from_output_dir.joinpath(DEFAULT_PACKAGE_DIR)
     for arch in package_dir.iterdir():
@@ -503,7 +499,7 @@ def _generate_repofiles(
             # TODO: purposefully ignoring the fact that options might be passed within the "main"
             # context of DNF options which would mean we'd have to generate a dnf.conf since such
             # options are global, skipping that for now
-            if dnf_options and dnf_options_repos and repoid in dnf_options_repos:
+            if dnf_options and repoid in dnf_options:
                 repofile[repoid] = dnf_options[repoid]
 
             localpath = for_output_dir.joinpath(DEFAULT_PACKAGE_DIR, arch.name, repoid)

--- a/hermeto/core/resolver.py
+++ b/hermeto/core/resolver.py
@@ -85,7 +85,4 @@ def _resolve_packages(request: Request) -> RequestOutput:
 
 def inject_files_post(from_output_dir: Path, for_output_dir: Path, **kwargs: Any) -> None:
     """Do extra steps for package manager."""
-    # if there is a callback method defined within the particular package manager, run it
-    if hasattr(rpm, "inject_files_post"):
-        callback_method = getattr(rpm, "inject_files_post")
-        callback_method(from_output_dir, for_output_dir, **kwargs)
+    rpm.inject_files_post(from_output_dir, for_output_dir, **kwargs)

--- a/hermeto/core/utils.py
+++ b/hermeto/core/utils.py
@@ -7,9 +7,11 @@ import re
 import shutil
 import subprocess
 import sys
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Sequence
 from functools import cache
+from itertools import filterfalse, tee
 from pathlib import Path
+from typing import Any
 
 from hermeto import APP_NAME
 from hermeto.core.config import get_config
@@ -204,4 +206,15 @@ def get_cache_dir() -> Path:
         cache_dir = Path(os.environ["XDG_CACHE_HOME"])
     except KeyError:
         cache_dir = Path.home().joinpath(".cache")
-    return cache_dir.joinpath(f"{APP_NAME}")
+    return cache_dir.joinpath(APP_NAME)
+
+
+def first_for(predicate: Callable, iterable: Iterable, fallback: Any) -> Any:
+    """Return the first match of predicate in iterable or fallback value."""
+    return next((x for x in iterable if predicate(x)), fallback)
+
+
+def partition_by(predicate: Callable, iterable: Iterable) -> tuple[Iterable, Iterable]:
+    """Partition iterable in two by predicate."""
+    i1, i2 = tee(iterable)
+    return filterfalse(predicate, i1), filter(predicate, i2)

--- a/hermeto/interface/cli.py
+++ b/hermeto/interface/cli.py
@@ -159,7 +159,7 @@ def version_callback(value: bool) -> None:
     if not value:
         return
 
-    print(f"{APP_NAME}", importlib.metadata.version("hermeto"))
+    print(APP_NAME, importlib.metadata.version("hermeto"))
     raise typer.Exit()
 
 

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -28,9 +28,6 @@ from tests.integration.proxy import (
     validate_and_strip_proxy_refs,
 )
 
-# force IPv4 localhost as 'localhost' can resolve with IPv6 as well
-TEST_SERVER_LOCALHOST = "127.0.0.1"
-
 HERMETO_TEST_IMAGE_TAG = "localhost/hermeto-test:latest"
 
 

--- a/tests/unit/models/test_input.py
+++ b/tests/unit/models/test_input.py
@@ -271,7 +271,7 @@ class TestPackageInput:
             pytest.param(
                 {"type": "pip", "requirements_build_files": ["weird/../subpath"]},
                 r"pip.requirements_build_files\n  Value error, path contains ..: weird/../subpath",
-                id="pip_path_references_parent_directory",
+                id="pip_build_path_references_parent_directory",
             ),
             pytest.param(
                 {"type": "pip", "requirements_files": None},

--- a/tests/unit/package_managers/gomod/test_go.py
+++ b/tests/unit/package_managers/gomod/test_go.py
@@ -384,6 +384,30 @@ def test_select_toolchain(
         assert str(result.version) == expected_result
 
 
+@mock.patch("hermeto.core.package_managers.gomod.go.Go.from_missing_toolchain")
+@mock.patch("hermeto.core.package_managers.gomod.go.Go._get_release")
+@mock.patch("hermeto.core.package_managers.gomod.go._get_gomod_version")
+def test_select_toolchain_returns_none_on_download_timeout(
+    mock_get_gomod_version: mock.Mock,
+    mock_go_get_release: mock.Mock,
+    mock_from_missing_toolchain: mock.Mock,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    # A download timeout must return None, not escape: TimeoutExpired is caught by
+    # neither _run nor _retry, so only _select_toolchain's handler stops it.
+    installed_versions = ["1.20", "1.19.2"]
+    mock_get_gomod_version.return_value = ("1.22", "1.22.1")
+    mock_go_get_release.side_effect = [f"go{v}" for v in installed_versions]
+    mock_from_missing_toolchain.side_effect = subprocess.TimeoutExpired(["go"], 1)
+
+    go_mod_file = rooted_tmp_path.join_within_root("go.mod")
+    go_mod_file.path.touch()
+
+    installed_toolchains = [Go(f"/usr/bin/go{v}") for v in installed_versions]
+
+    assert _select_toolchain(go_mod_file, installed_toolchains) is None
+
+
 @pytest.mark.parametrize(
     "PATH,file_tree,binary_count",
     [

--- a/tests/unit/package_managers/javascript/npm/test_resolver.py
+++ b/tests/unit/package_managers/javascript/npm/test_resolver.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-only
 import json
 import os
-import urllib.parse
 from typing import Any
 from unittest import mock
 
@@ -26,10 +25,6 @@ from hermeto.core.package_managers.javascript.npm.resolver import (
 )
 from hermeto.core.package_managers.javascript.npm.utils import NormalizedUrl
 from hermeto.core.rooted_path import RootedPath
-
-
-def urlq(url: str) -> str:
-    return urllib.parse.quote(url, safe=":/")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/package_managers/javascript/yarn/test_main.py
+++ b/tests/unit/package_managers/javascript/yarn/test_main.py
@@ -83,15 +83,6 @@ class YarnVersions(Enum):
         )
 
 
-SAMPLE_PLUGINS = """
-plugins:
-  - path: .yarn/plugins/@yarnpkg/plugin-typescript.cjs
-    spec: "@yarnpkg/plugin-typescript"
-  - path: .yarn/plugins/@yarnpkg/plugin-exec.cjs
-    spec: "@yarnpkg/plugin-exec"
-"""
-
-
 @pytest.mark.parametrize(
     "yarn_path_version, package_manager_version",
     [

--- a/tests/unit/package_managers/javascript/yarn/test_resolver.py
+++ b/tests/unit/package_managers/javascript/yarn/test_resolver.py
@@ -900,7 +900,7 @@ def test_get_path_patch_url(
 
     mock_project = mock.Mock(source_dir=source_dir)
     resolver = _ComponentResolver(
-        {}, set(), [patch_locator], mock_project, rooted_tmp_path.re_root("output")
+        set(), [patch_locator], mock_project, rooted_tmp_path.re_root("output")
     )
 
     actual_url = resolver._get_path_patch_url(patch_locator, patch_path)
@@ -923,7 +923,7 @@ def test_get_builtin_patch_url(
 
     mock_project = mock.Mock(source_dir=source_dir)
     resolver = _ComponentResolver(
-        {}, set(), [patch_locator], mock_project, rooted_tmp_path.re_root("output")
+        set(), [patch_locator], mock_project, rooted_tmp_path.re_root("output")
     )
 
     actual_url = resolver._get_builtin_patch_url(builtin_patch, Version(3, 0, 0))
@@ -963,7 +963,7 @@ def test_pedigree_mapping_flattens_nested_patches(
 
     mock_project = mock.Mock(source_dir=source_dir)
     resolver = _ComponentResolver(
-        {}, set(), [patch_locator1, patch_locator2], mock_project, rooted_tmp_path.re_root("output")
+        set(), [patch_locator1, patch_locator2], mock_project, rooted_tmp_path.re_root("output")
     )
 
     actual_pedigree = resolver._get_pedigree_mapping([patch_locator1, patch_locator2])
@@ -1023,9 +1023,7 @@ def test_get_pedigree_with_unsupported_locators(
     mock_project = mock.Mock(source_dir=rooted_tmp_path.re_root("source"))
 
     with pytest.raises(UnsupportedFeature):
-        _ComponentResolver(
-            {}, set(), patch_locators, mock_project, rooted_tmp_path.re_root("output")
-        )
+        _ComponentResolver(set(), patch_locators, mock_project, rooted_tmp_path.re_root("output"))
 
 
 @mock.patch("hermeto.core.package_managers.javascript.yarn.resolver.get_config")
@@ -1172,7 +1170,7 @@ def test_path_patch_raises_without_repo_in_permissive_mode(
     mock_proj = mock.Mock(source_dir=source_dir)
 
     with pytest.raises(PackageRejected):
-        _ComponentResolver({}, set(), [patch_locator], mock_proj, rooted_tmp_path.re_root("output"))
+        _ComponentResolver(set(), [patch_locator], mock_proj, rooted_tmp_path.re_root("output"))
 
 
 @mock.patch("hermeto.core.package_managers.javascript.yarn.resolver.run_yarn_cmd")
@@ -1255,7 +1253,6 @@ class TestGitPurlMapping:
         output_dir = rooted_tmp_path.re_root("output")
 
         resolver = _ComponentResolver(
-            {file_locator: mock.Mock()},
             set(),
             [],
             mock_project,
@@ -1286,7 +1283,6 @@ class TestGitPurlMapping:
         output_dir = rooted_tmp_path.re_root("output")
 
         resolver = _ComponentResolver(
-            {file_locator: mock.Mock()},
             set(),
             [],
             mock_project,

--- a/tests/unit/package_managers/javascript/yarn_classic/test_project.py
+++ b/tests/unit/package_managers/javascript/yarn_classic/test_project.py
@@ -90,11 +90,6 @@ def _prepare_yarn_lock_file(rooted_tmp_path: RootedPath, content: str) -> YarnLo
     return YarnLock.from_file(path)
 
 
-def test_yarn_lock_path(rooted_tmp_path: RootedPath) -> None:
-    yarn_lock = _prepare_yarn_lock_file(rooted_tmp_path, VALID_YARN_LOCK_FILE)
-    assert yarn_lock.path.root == rooted_tmp_path.root
-
-
 def test_parse_yarn_lock(rooted_tmp_path: RootedPath) -> None:
     yarn_lock = _prepare_yarn_lock_file(rooted_tmp_path, VALID_YARN_LOCK_FILE)
     assert yarn_lock.data == lockfile.Lockfile.from_str(VALID_YARN_LOCK_FILE).data

--- a/tests/unit/package_managers/python/pip/test_requirements.py
+++ b/tests/unit/package_managers/python/pip/test_requirements.py
@@ -613,7 +613,7 @@ class TestPipRequirementsFile:
         """Test scenarios in PipRequirement that cannot be triggered via PipRequirementsFile."""
         # Empty lines are NOT ignored
         with pytest.raises(UnexpectedFormat):
-            assert PipRequirement.from_line("     ", []) is None
+            PipRequirement.from_line("     ", [])
 
         with pytest.raises(UnexpectedFormat):
             PipRequirement.from_line("aiowsgi==0.7 \nasn1crypto==1.3.0", [])

--- a/tests/unit/package_managers/test_generic.py
+++ b/tests/unit/package_managers/test_generic.py
@@ -582,6 +582,30 @@ class TestLockfileArtifactAuth:
         with pytest.raises(ValidationError):
             LockfileArtifactAuth()
 
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            pytest.param({"basic": None}, id="basic_explicitly_set_to_none"),
+            pytest.param({"bearer": None}, id="bearer_none"),
+            pytest.param({"basic": None, "bearer": None}, id="both_none"),
+        ],
+    )
+    def test_raise_error_when_auth_value_is_none(self, kwargs: dict[str, Any]) -> None:
+        with pytest.raises(ValidationError):
+            LockfileArtifactAuth(**kwargs)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param("not-a-mapping", id="string"),
+            pytest.param(["basic"], id="list"),
+        ],
+    )
+    def test_raise_error_when_auth_is_not_a_mapping(self, value: Any) -> None:
+        # A non-mapping value must yield a clean ValidationError.
+        with pytest.raises(ValidationError):
+            LockfileArtifactAuth.model_validate(value)
+
 
 @pytest.mark.parametrize(
     ["lockfile_content", "expected_url", "expected_headers"],

--- a/tests/unit/test_checksum.py
+++ b/tests/unit/test_checksum.py
@@ -158,17 +158,6 @@ def test_verify_checksum_failure(
 
 
 @pytest.mark.parametrize(
-    "checksum, algorithm, expected",
-    [
-        (SHA512_HEX, "sha512", SHA512_SRI),
-        ("a" * 40, "sha1", "sha1-qqqqqqqqqqqqqqqqqqqqqqqqqqo="),
-    ],
-)
-def test_convert_hex_checksum_to_sri(checksum: str, algorithm: str, expected: str) -> None:
-    assert ChecksumInfo(algorithm, checksum).to_sri() == expected
-
-
-@pytest.mark.parametrize(
     "integrity, algorithm, expected",
     [
         (SHA512_SRI, "sha512", SHA512_HEX),

--- a/tests/unit/test_merge_spdx.py
+++ b/tests/unit/test_merge_spdx.py
@@ -280,7 +280,7 @@ def test_merging_spdx_on_self_does_not_modify_the_sbom(
 
 
 def _same_relationship_order(sbom1: SPDXSbom, sbom2: SPDXSbom) -> bool:
-    for r1, r2 in zip(sbom1.relationships, sbom2.relationships):
+    for r1, r2 in zip(sbom1.relationships, sbom2.relationships, strict=True):
         if r1 != r2:
             return False
     return True


### PR DESCRIPTION
Remove dead production code and fix subtle bugs found during a codebase sweep.

- Fix pydantic v1 leftovers, auth validation, missing try/finally guards,
  dropped exception chains, wrong type annotations, and other silent bugs
- Remove unused functions, parameters, fields, type aliases, and constants
- Remove redundant guards that became dead after later refactors
- Clean up unused loggers, redundant expressions, and stale test infrastructure

Fixes come first (commits 1-3), cleanup after (commits 4-9).

Closes https://github.com/hermetoproject/hermeto/issues/1723