### PR TITLE
fix(nexus): remove nexus service dep from nginx

### DIFF
--- a/tests/nexusserver/docker-compose.yml
+++ b/tests/nexusserver/docker-compose.yml
@@ -27,9 +27,6 @@ services:
       - ../certificates/server.crt:/etc/nginx/certs/server.crt:ro,z
       - ../certificates/server.key:/etc/nginx/certs/server.key:ro,z
       - ../certificates/CA.crt:/etc/nginx/certs/CA.crt:ro,z
-    depends_on:
-      nexus:
-        condition: service_healthy
 
 volumes:
   nexus-data:


### PR DESCRIPTION
The "service is healthy" condition has no timeout in podman-compose, which can lead to indefinite hangs. The configure script for Nexus should be able to handle the wait-until-ready condition.

This doesn't fix whatever is intermittently causing Nexus to fail to reach a healthy state, but it will at least prevent it from waiting six hours for the Github CI to timeout.