### PR TITLE
 Skip documentation-only changes with 'paths-ignore'

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -2,7 +2,17 @@ name: Gating
 
 on:
   pull_request:
+    # Documentation-only changes cannot break CI.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'mkdocs.yml'
   push:
+    # Documentation-only changes cannot break CI.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'mkdocs.yml'
     branches:
       - main
   merge_group:


### PR DESCRIPTION
Documentation-only changes can not affect the ci result. it's a good optimization to exclude these files from the gating workflow.

Exluded file:
- '**/*.md'
- 'docs/**'
- 'mkdocs.yml'

Closes https://github.com/hermetoproject/hermeto/issues/1721