### PR TITLE
refactor: adopt more-itertools for iterable manipulation

### DIFF
--- a/hermeto/core/models/sbom.py
+++ b/hermeto/core/models/sbom.py
@@ -8,19 +8,19 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from functools import cached_property, partial, reduce
-from itertools import chain, groupby
+from itertools import groupby
 from pathlib import Path
 from typing import Annotated, Any, Callable, Literal, Union
 from urllib.parse import urlparse
 
 import pydantic
+from more_itertools import first_true, flatten
 from packageurl import PackageURL
 from typing_extensions import Self
 
 from hermeto import APP_NAME
 from hermeto.core.errors import UnexpectedFormat
 from hermeto.core.models.property_semantics import Property, PropertyEnum, PropertySet
-from hermeto.core.utils import first_for
 
 log = logging.getLogger(__name__)
 
@@ -308,11 +308,9 @@ class Sbom(pydantic.BaseModel):
                 # in the future. It is a very rare corner case, though, and it only matters when
                 # merging multiple CycloneDX SBOMs.
                 annotations=merge_component_annotations(
-                    chain.from_iterable(s.annotations for s in [self, other])
+                    flatten(s.annotations for s in [self, other])
                 ),
-                components=merge_component_properties(
-                    chain.from_iterable(s.components for s in [self, other])
-                ),
+                components=merge_component_properties(flatten(s.components for s in [self, other])),
             )
         else:
             return self + other.to_cyclonedx()
@@ -799,7 +797,9 @@ class SPDXSbom(pydantic.BaseModel):
         unidirectionally_related_package = lambda p: inverse_relationships.get(p) == self.SPDXID
         # Note: defaulting to top-level SPDXID is inherited from the original implementation.
         # It is unclear if it is really needed, but is left around to match the precedent.
-        root_id = first_for(unidirectionally_related_package, direct_relationships, self.SPDXID)
+        root_id = first_true(
+            direct_relationships, default=self.SPDXID, pred=unidirectionally_related_package
+        )
         return root_id
 
     # NOTE: having this as cached will cause trouble when sequentially

--- a/hermeto/core/package_managers/gomod/go.py
+++ b/hermeto/core/package_managers/gomod/go.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Sequence
 
 import pydantic
+from more_itertools import first
 from packaging import version
 from pydantic.alias_generators import to_pascal
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
@@ -464,7 +465,7 @@ def _select_toolchain(go_mod_file: RootedPath, installed_toolchains: Iterable[Go
             log.debug("Installing Go toolchain version '%s'", target_version)
             release_str = f"go{str(target_version)}"
             try:
-                work_toolchain = next(iter(installed_toolchains))
+                work_toolchain = first(installed_toolchains)
                 go = Go.from_missing_toolchain(release_str, work_toolchain.binary)
                 log.debug("Using Go toolchain version '%s'", go.version)
             except Exception as ex:

--- a/hermeto/core/package_managers/javascript/npm/resolver.py
+++ b/hermeto/core/package_managers/javascript/npm/resolver.py
@@ -8,6 +8,7 @@ from typing import Any
 from urllib.parse import urlparse
 
 import aiohttp
+from more_itertools import partition
 
 from hermeto.core.checksum import ChecksumInfo, must_match_any_checksum
 from hermeto.core.config import get_config
@@ -163,16 +164,11 @@ def _get_npm_dependencies(
                 "proxy_auth": proxy_auth,
             }
 
-    files_with_auth = {
-        str(f["fetch_url"]): f["download_path"]
-        for f in files_to_download.values()
-        if f["proxy_auth"] is not None
-    }
-    files_without_auth = {
-        str(f["fetch_url"]): f["download_path"]
-        for f in files_to_download.values()
-        if f["proxy_auth"] is None
-    }
+    without_auth, with_auth = partition(
+        lambda f: f["proxy_auth"] is not None, files_to_download.values()
+    )
+    files_with_auth = {str(f["fetch_url"]): f["download_path"] for f in with_auth}
+    files_without_auth = {str(f["fetch_url"]): f["download_path"] for f in without_auth}
     asyncio.run(async_download_with_auth(files_without_auth, files_with_auth, npm_proxy_basic_auth))
 
     # Check integrity of downloaded packages

--- a/hermeto/core/package_managers/javascript/pnpm/resolver.py
+++ b/hermeto/core/package_managers/javascript/pnpm/resolver.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from more_itertools import first_true
 from packageurl import PackageURL
 
 from hermeto.core.config import get_config
@@ -31,7 +32,6 @@ from hermeto.core.package_managers.javascript.yarn_classic.workspaces import (
     get_workspace_paths,
 )
 from hermeto.core.rooted_path import RootedPath
-from hermeto.core.utils import first_for
 
 log = logging.getLogger(__name__)
 
@@ -139,7 +139,9 @@ def _generate_pedigree_for(
 
     # Dependencies can be patched by package ID or package name (including scope).
     search_keys = (package.id, package.full_name)
-    key = first_for(lambda search_key: search_key in patched_dependencies, search_keys, None)
+    key = first_true(
+        search_keys, default=None, pred=lambda search_key: search_key in patched_dependencies
+    )
 
     return Pedigree(patches=[Patch(diff=PatchDiff(url=get_patch_url(key)))]) if key else None
 

--- a/hermeto/core/package_managers/javascript/yarn_classic/main.py
+++ b/hermeto/core/package_managers/javascript/yarn_classic/main.py
@@ -5,6 +5,8 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, ClassVar
 
+from more_itertools import all_equal
+
 from hermeto import APP_NAME
 from hermeto.core.errors import (
     ExitError,
@@ -267,7 +269,7 @@ def _verify_no_offline_mirror_collisions(packages: Iterable[YarnClassicPackage])
         tarball_collisions[tarball_name].append(p)
 
     for tarball_name, packages in tarball_collisions.items():
-        if all(pkg == packages[0] for pkg in packages):
+        if all_equal(packages):
             continue
 
         raise PackageManagerError(

--- a/hermeto/core/package_managers/javascript/yarn_classic/workspaces.py
+++ b/hermeto/core/package_managers/javascript/yarn_classic/workspaces.py
@@ -2,9 +2,10 @@
 import logging
 from collections.abc import Generator, Iterable
 from dataclasses import dataclass
-from itertools import chain
 from pathlib import Path
 from typing import Any
+
+from more_itertools import flatten
 
 from hermeto.core.package_managers.javascript.package_json import PackageJson
 from hermeto.core.rooted_path import RootedPath
@@ -49,7 +50,7 @@ def get_workspace_paths(workspaces_globs: list[str], source_dir: RootedPath) -> 
     def all_paths_matching(glob: str) -> Generator[Path, None, None]:
         return (path.resolve() for path in source_dir.path.glob(glob) if path.is_dir())
 
-    return list(chain.from_iterable(map(all_paths_matching, workspaces_globs)))
+    return list(flatten(map(all_paths_matching, workspaces_globs)))
 
 
 def _extract_workspaces_globs(package: dict[str, Any]) -> list[str]:

--- a/hermeto/core/package_managers/python/pip/rust.py
+++ b/hermeto/core/package_managers/python/pip/rust.py
@@ -7,6 +7,7 @@ from collections.abc import Iterable
 from pathlib import Path
 
 import tomlkit
+from more_itertools import ilen
 
 from hermeto.core.models.input import CargoPackageInput, Request
 from hermeto.core.models.output import EnvironmentVariable, ProjectFile, RequestOutput
@@ -88,7 +89,7 @@ def filter_packages_with_rust_code(packages: list[PipPackage]) -> list[CargoPack
 
         # The unpacked URL/VCS package may have an arbitrary directory name that we cannot control.
         # Therefore, it is inside a predictable directory derived from the package name.
-        nitems = sum(1 for _ in extract_dir.iterdir())
+        nitems = ilen(extract_dir.iterdir())
         if nitems != 1:
             # non-standard packaging scheme that doesn't come with a top-level directory
             source_dir = extract_dir

--- a/hermeto/core/utils.py
+++ b/hermeto/core/utils.py
@@ -7,11 +7,9 @@ import re
 import shutil
 import subprocess
 import sys
-from collections.abc import Callable, Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from functools import cache
-from itertools import filterfalse, tee
 from pathlib import Path
-from typing import Any
 
 from hermeto import APP_NAME
 from hermeto.core.config import get_config
@@ -207,14 +205,3 @@ def get_cache_dir() -> Path:
     except KeyError:
         cache_dir = Path.home().joinpath(".cache")
     return cache_dir.joinpath(f"{APP_NAME}")
-
-
-def first_for(predicate: Callable, iterable: Iterable, fallback: Any) -> Any:
-    """Return the first match of predicate in iterable or fallback value."""
-    return next((x for x in iterable if predicate(x)), fallback)
-
-
-def partition_by(predicate: Callable, iterable: Iterable) -> tuple[Iterable, Iterable]:
-    """Partition iterable in two by predicate."""
-    i1, i2 = tee(iterable)
-    return filterfalse(predicate, i1), filter(predicate, i2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "aiohttp-retry",
   "createrepo-c ; sys_platform == 'linux'",
   "gitpython",
+  "more-itertools",
   "packageurl-python",
   "packaging",
   "pyarn",

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -900,6 +900,10 @@ mkdocs-material-extensions==1.3.1 \
     --hash=sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443 \
     --hash=sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31
     # via mkdocs-material
+more-itertools==11.1.0 \
+    --hash=sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d \
+    --hash=sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192
+    # via hermeto (pyproject.toml)
 multidict==6.7.1 \
     --hash=sha256:026d264228bcd637d4e060844e39cdc60f86c479e463d49075dedc21b18fbbe0 \
     --hash=sha256:03ede2a6ffbe8ef936b92cb4529f27f42be7f56afcdab5ab739cd5f27fb1cbf9 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -471,6 +471,10 @@ mdurl==0.1.2 \
     --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \
     --hash=sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
     # via markdown-it-py
+more-itertools==11.1.0 \
+    --hash=sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d \
+    --hash=sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192
+    # via hermeto (pyproject.toml)
 multidict==6.7.1 \
     --hash=sha256:026d264228bcd637d4e060844e39cdc60f86c479e463d49075dedc21b18fbbe0 \
     --hash=sha256:03ede2a6ffbe8ef936b92cb4529f27f42be7f56afcdab5ab739cd5f27fb1cbf9 \

--- a/tests/unit/package_managers/maven/test_main.py
+++ b/tests/unit/package_managers/maven/test_main.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-only
 from pathlib import Path
 
+from more_itertools import first
+
 from hermeto.core.package_managers.maven.main import (
     MIRROR_ID,
     _get_matching_pom_files,
@@ -22,7 +24,7 @@ def test_get_matching_pom_files(tmp_path: Path) -> None:
         }
     )
     poms = _get_matching_pom_files(tmp_path, [ma])
-    url = next(iter(poms.keys()))
+    url = first(poms.keys())
     assert url == "https://repo.maven.apache.org/maven2/g/a/1/a-1.pom"
 
 


### PR DESCRIPTION
Add more-itertools as a dependency and replace:
- first_for() with first_true()
- partition_by() with partition()
- chain.from_iterable() with flatten()
- next(iter(x)) with first()
- all(x == xs[0] for x in xs) with all_equal()
- sum(1 for _ in x) with ilen()

Delete first_for and partition_by from utils.py as they now have no callers.

Use partition in resolver.py where it should have been used before

Resolves https://github.com/hermetoproject/hermeto/issues/1355


Assisted-by: Claude