### PR TITLE
chore(deps): bump pymdown-extensions > 11.0.0

### DIFF
--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -1418,9 +1418,9 @@ pygments==2.20.0 \
     #   mkdocs-material
     #   pytest
     #   rich
-pymdown-extensions==11.0 \
-    --hash=sha256:8269cef0247f9e2d0a62fcea10860aba05c1cbab5470fd4b63230b96434dc589 \
-    --hash=sha256:fbc4acb641814fa9d17521bbd21a5240ef739a662f11c06330c4b78c93e954d6
+pymdown-extensions==11.0.1 \
+    --hash=sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2 \
+    --hash=sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0
     # via mkdocs-material
 pypi-simple==1.8.0 \
     --hash=sha256:466f2fcd0d723822aae3a0ccfda22e68ff8cd7f50aae68911946ab1dd1d587e1 \


### PR DESCRIPTION
Addresses dependabot alert on GHSA-gm37-52c6-37mw. Note pymdown-extensions is a docs dependency.