### PR TITLE
cargo: Drop authors field from Cargo.toml files

### DIFF
--- a/tests/integration/cargo/scenarios/cargo_e2e/in/heck/Cargo.toml
+++ b/tests/integration/cargo/scenarios/cargo_e2e/in/heck/Cargo.toml
@@ -1,5 +1,4 @@
 [package]
-authors = ["Without Boats <woboats@gmail.com>"]
 name = "heck"
 version = "0.4.1"
 edition = "2018"

--- a/tests/integration/cargo/scenarios/cargo_e2e/out/bom.json
+++ b/tests/integration/cargo/scenarios/cargo_e2e/out/bom.json
@@ -16,7 +16,7 @@
         "pkg:cargo/anstyle-wincon@3.0.2?checksum=1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7",
         "pkg:cargo/anstyle@1.0.4?checksum=7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87",
         "pkg:cargo/autocfg@1.1.0?checksum=d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
-        "pkg:cargo/bombadil@0.2.0?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%4011346d5f32a7b34421a30922623a8a120a0d56b8#bombadil",
+        "pkg:cargo/bombadil@0.2.0?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40bbc0fc75b0d0c576e43ad5aa320854c1b6108dd5#bombadil",
         "pkg:cargo/bumpalo@3.14.0?checksum=7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec",
         "pkg:cargo/cc@1.0.83?checksum=f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0",
         "pkg:cargo/cfg-if@1.0.0?checksum=baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
@@ -31,7 +31,7 @@
         "pkg:cargo/encode_unicode@0.3.6?checksum=a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f",
         "pkg:cargo/getrandom@0.1.16?checksum=8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce",
         "pkg:cargo/getrandom@0.2.11?checksum=fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f",
-        "pkg:cargo/heck@0.4.1?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%4011346d5f32a7b34421a30922623a8a120a0d56b8#heck",
+        "pkg:cargo/heck@0.4.1?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40bbc0fc75b0d0c576e43ad5aa320854c1b6108dd5#heck",
         "pkg:cargo/iana-time-zone-haiku@0.1.2?checksum=f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f",
         "pkg:cargo/iana-time-zone@0.1.58?checksum=8326b86b6cff230b97d0d312a6c40a60726df3332e721f72a1b035f451663b20",
         "pkg:cargo/indicatif@0.17.7?checksum=fb28741c9db9a713d93deb3bb9515c20788cef5815265bee4980e87bde7e0f25",
@@ -55,7 +55,7 @@
         "pkg:cargo/rand_core@0.6.3?vcs_url=git%2Bhttps://github.com/rust-random/rand%408792268dfe57e49bb4518190bf4fe66176759a44",
         "pkg:cargo/rand_hc@0.2.0?checksum=ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c",
         "pkg:cargo/rand_hc@0.3.1?vcs_url=git%2Bhttps://github.com/rust-random/rand%408792268dfe57e49bb4518190bf4fe66176759a44",
-        "pkg:cargo/rustic@0.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%4011346d5f32a7b34421a30922623a8a120a0d56b8",
+        "pkg:cargo/rustic@0.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40bbc0fc75b0d0c576e43ad5aa320854c1b6108dd5",
         "pkg:cargo/smawk@0.3.2?checksum=b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c",
         "pkg:cargo/strsim@0.10.0?checksum=73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
         "pkg:cargo/syn@2.0.43?checksum=ee659fb5f3d355364e1f3e5bc10fb82068efbf824a1e9d1c9504244a6469ad53",
@@ -64,7 +64,7 @@
         "pkg:cargo/unicode-linebreak@0.1.5?checksum=3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f",
         "pkg:cargo/unicode-width@0.1.11?checksum=e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85",
         "pkg:cargo/utf8parse@0.2.1?checksum=711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a",
-        "pkg:cargo/utils@0.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%4011346d5f32a7b34421a30922623a8a120a0d56b8#packages/utils",
+        "pkg:cargo/utils@0.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40bbc0fc75b0d0c576e43ad5aa320854c1b6108dd5#packages/utils",
         "pkg:cargo/wasi@0.11.0%2Bwasi-snapshot-preview1?checksum=9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423",
         "pkg:cargo/wasi@0.9.0%2Bwasi-snapshot-preview1?checksum=cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519",
         "pkg:cargo/wasm-bindgen-backend@0.2.89?checksum=1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826",
@@ -224,7 +224,7 @@
       "version": "1.1.0"
     },
     {
-      "bom-ref": "pkg:cargo/bombadil@0.2.0?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%4011346d5f32a7b34421a30922623a8a120a0d56b8#bombadil",
+      "bom-ref": "pkg:cargo/bombadil@0.2.0?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40bbc0fc75b0d0c576e43ad5aa320854c1b6108dd5#bombadil",
       "name": "bombadil",
       "properties": [
         {
@@ -232,7 +232,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:cargo/bombadil@0.2.0?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%4011346d5f32a7b34421a30922623a8a120a0d56b8#bombadil",
+      "purl": "pkg:cargo/bombadil@0.2.0?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40bbc0fc75b0d0c576e43ad5aa320854c1b6108dd5#bombadil",
       "type": "library",
       "version": "0.2.0"
     },
@@ -419,7 +419,7 @@
       "version": "0.2.11"
     },
     {
-      "bom-ref": "pkg:cargo/heck@0.4.1?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%4011346d5f32a7b34421a30922623a8a120a0d56b8#heck",
+      "bom-ref": "pkg:cargo/heck@0.4.1?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40bbc0fc75b0d0c576e43ad5aa320854c1b6108dd5#heck",
       "name": "heck",
       "properties": [
         {
@@ -427,7 +427,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:cargo/heck@0.4.1?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%4011346d5f32a7b34421a30922623a8a120a0d56b8#heck",
+      "purl": "pkg:cargo/heck@0.4.1?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40bbc0fc75b0d0c576e43ad5aa320854c1b6108dd5#heck",
       "type": "library",
       "version": "0.4.1"
     },
@@ -731,7 +731,7 @@
       "version": "0.3.1"
     },
     {
-      "bom-ref": "pkg:cargo/rustic@0.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%4011346d5f32a7b34421a30922623a8a120a0d56b8",
+      "bom-ref": "pkg:cargo/rustic@0.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40bbc0fc75b0d0c576e43ad5aa320854c1b6108dd5",
       "name": "rustic",
       "properties": [
         {
@@ -739,7 +739,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:cargo/rustic@0.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%4011346d5f32a7b34421a30922623a8a120a0d56b8",
+      "purl": "pkg:cargo/rustic@0.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40bbc0fc75b0d0c576e43ad5aa320854c1b6108dd5",
       "type": "library",
       "version": "0.1.0"
     },
@@ -848,7 +848,7 @@
       "version": "0.2.1"
     },
     {
-      "bom-ref": "pkg:cargo/utils@0.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%4011346d5f32a7b34421a30922623a8a120a0d56b8#packages/utils",
+      "bom-ref": "pkg:cargo/utils@0.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40bbc0fc75b0d0c576e43ad5aa320854c1b6108dd5#packages/utils",
       "name": "utils",
       "properties": [
         {
@@ -856,7 +856,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:cargo/utils@0.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%4011346d5f32a7b34421a30922623a8a120a0d56b8#packages/utils",
+      "purl": "pkg:cargo/utils@0.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/hermeto.git%40bbc0fc75b0d0c576e43ad5aa320854c1b6108dd5#packages/utils",
       "type": "library",
       "version": "0.1.0"
     },


### PR DESCRIPTION
The field is deprecated [1]. The deprecation warning shines like crazy in my IDE with Rust/TOML plugins.

The project was copied from [1], and commit [2] addressed this already.

---
[1]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-authors-field [2]: https://github.com/withoutboats/heck
[3]: https://github.com/withoutboats/heck/commit/1fd5c7e306d55b5bdf73d7ee83454b852ecf7ec3