### PR TITLE
feat: log proxy usage at INFO level for all applicable backends

### DIFF
--- a/hermeto/core/package_managers/bundler/main.py
+++ b/hermeto/core/package_managers/bundler/main.py
@@ -112,6 +112,8 @@ def _download_gems(
     """Download rubygems registry dependencies, rewriting URLs through a proxy if configured."""
     config = get_config()
     proxy_url = config.bundler.proxy_url
+    if proxy_url is not None:
+        log.info("Using registry proxy %s for registry dependencies", proxy_url)
     proxy_auth = (
         aiohttp.encode_basic_auth(
             login=config.bundler.proxy_login,

--- a/hermeto/core/package_managers/cargo/main.py
+++ b/hermeto/core/package_managers/cargo/main.py
@@ -243,6 +243,8 @@ def _fetch_dependencies(package_dir: RootedPath, request: Request) -> CargoVendo
         str(vendor_dir),
     ]
     log.info("Fetching cargo dependencies at %s", package_dir)
+    if (proxy_url := get_config().cargo.proxy_url) is not None:
+        log.info("Using registry proxy %s for registry dependencies", proxy_url)
     # NOTE: ordering is important here, a config must be sanitized first, extended to use
     # a proxy after that, otherwise proxy data will be scrubbed by the sanitizer.
     with (

--- a/hermeto/core/package_managers/gomod/main.py
+++ b/hermeto/core/package_managers/gomod/main.py
@@ -756,6 +756,7 @@ def _prepare_run_params(
         "GOTOOLCHAIN": "auto",
     }
     if config.gomod.proxy_url:
+        log.info("Using registry proxy %s for registry dependencies", config.gomod.proxy_url)
         go_vars["GOPROXY"] = config.gomod.proxy_url
 
     if config.gomod.proxy_login is not None:

--- a/hermeto/core/package_managers/javascript/npm/resolver.py
+++ b/hermeto/core/package_managers/javascript/npm/resolver.py
@@ -108,6 +108,8 @@ def _get_npm_dependencies(
     files_to_download: dict[str, dict[str, Any]] = {}
     download_paths = {}
     config = get_config()
+    if (proxy_url := config.npm.proxy_url) is not None:
+        log.info("Using registry proxy %s for registry dependencies", proxy_url)
     npm_proxy_basic_auth = None
     if config.npm.proxy_login and config.npm.proxy_password:
         npm_proxy_basic_auth = aiohttp.encode_basic_auth(

--- a/hermeto/core/package_managers/javascript/pnpm/main.py
+++ b/hermeto/core/package_managers/javascript/pnpm/main.py
@@ -77,6 +77,8 @@ def _resolve_pnpm_project(
 def _download_resolved_packages(packages: list[PnpmPackage], deps_dir: Path) -> None:
     config = get_config()
     proxy_url = config.pnpm.proxy_url
+    if proxy_url is not None:
+        log.info("Using registry proxy %s for registry dependencies", proxy_url)
     proxy_login = config.pnpm.proxy_login
     proxy_password = config.pnpm.proxy_password
 

--- a/hermeto/core/package_managers/javascript/yarn/main.py
+++ b/hermeto/core/package_managers/javascript/yarn/main.py
@@ -258,6 +258,7 @@ def _set_yarnrc_configuration(
 
     config = get_config()
     if (proxy_url := config.yarn.proxy_url) is not None:
+        log.info("Using registry proxy %s for registry dependencies", proxy_url)
         yarn_rc["npmRegistryServer"] = str(proxy_url)
         login = config.yarn.proxy_login
         password = config.yarn.proxy_password

--- a/hermeto/core/package_managers/python/pip/main.py
+++ b/hermeto/core/package_managers/python/pip/main.py
@@ -424,6 +424,8 @@ def _resolve_and_download_pypi_packages(
     """Resolve and download all PyPI packages."""
     config = get_config()
     proxy_url = str(config.pip.proxy_url) if config.pip.proxy_url is not None else None
+    if proxy_url is not None:
+        log.info("Using registry proxy %s for registry dependencies", proxy_url)
     # A proxy must be used only if an index is the standard one, custom indices must
     # be preserved. A custom index would always override proxy.
     is_standard = lambda index_url: index_url and index_url == pypi_simple.PYPI_SIMPLE_ENDPOINT


### PR DESCRIPTION
When hermeto prefetches dependencies via a proxy, there was no way
for users to confirm at runtime that the proxy was actually being used.
This PR adds INFO-level logging of proxy usage across all applicable
backends, closing https://github.com/hermetoproject/hermeto/issues/1699.

Backends covered:
- pip
- npm
- pnpm
- yarn (classic + v2+)
- bundler
- cargo
- gomod
