### PR TITLE
fix: send a descriptive User-Agent on all HTTP requests

### DIFF
--- a/hermeto/core/package_managers/general.py
+++ b/hermeto/core/package_managers/general.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import asyncio
+import importlib.metadata
 import logging
 import ssl
 import types
@@ -20,6 +21,7 @@ from urllib3.connectionpool import ConnectionPool
 from urllib3.response import BaseHTTPResponse
 from urllib3.util.retry import Retry
 
+from hermeto import APP_NAME
 from hermeto.core.config import ProxyUrl, get_config
 from hermeto.core.errors import FetchError
 from hermeto.core.scm import get_repo_id
@@ -31,6 +33,27 @@ SAFE_REQUEST_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
 BACKOFF_FACTOR = 1.3
 STATUS_FORCELIST = (500, 502, 503, 504)
 DEFAULT_CHUNK_SIZE = 65536  # 64KB
+
+
+def _get_user_agent() -> str:
+    """
+    Build a descriptive User-Agent string identifying hermeto to remote servers.
+
+    The default User-Agent sent by requests/aiohttp (e.g. "python-requests/2.34.2",
+    "Python/3.12 aiohttp/3.14.1") is indistinguishable from generic scraping traffic
+    and gets blocked by some package registries' WAFs (see
+    https://central.sonatype.org/faq/429-tooling-provider/). This affects every
+    hermeto HTTP request, including ones unrelated to the artifact that tripped the
+    block, since some WAFs blackhole the whole source IP once triggered.
+    """
+    try:
+        version = importlib.metadata.version("hermeto")
+    except importlib.metadata.PackageNotFoundError:
+        version = "unknown"
+    return f"{APP_NAME}/{version} (+https://github.com/hermetoproject/hermeto)"
+
+
+USER_AGENT: str = _get_user_agent()
 
 log = logging.getLogger(__name__)
 
@@ -84,6 +107,7 @@ def _get_pkg_requests_session() -> requests.Session:
     if _pkg_requests_session is None:
         max_retries = get_config().http.max_retries
         _pkg_requests_session = Session()
+        _pkg_requests_session.headers["User-Agent"] = USER_AGENT
         adapter = HTTPAdapter(
             max_retries=SyncLoggingRetry(
                 backoff_factor=BACKOFF_FACTOR,
@@ -256,6 +280,7 @@ async def async_download_files(
         trust_env=True,
         # preserve percent-encoding in redirect URLs (e.g. signed CloudFront URLs)
         requote_redirect_url=False,
+        headers={"User-Agent": USER_AGENT},
     )
 
     async with retry_client as session:

--- a/hermeto/core/package_managers/general.py
+++ b/hermeto/core/package_managers/general.py
@@ -189,7 +189,11 @@ async def _async_download_binary_file(
 
     try:
         async with session.get(
-            url, timeout=timeout, raise_for_status=True, ssl=ssl_context, headers=headers
+            url,
+            timeout=timeout,
+            raise_for_status=True,
+            ssl=ssl_context,
+            headers={**(headers or {}), "User-Agent": _get_user_agent()},
         ) as response:
             async with aiofiles.open(download_path, "wb") as f:
                 async for chunk in response.content.iter_chunked(chunk_size):

--- a/hermeto/core/package_managers/general.py
+++ b/hermeto/core/package_managers/general.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import asyncio
+import functools
 import importlib.metadata
 import logging
 import ssl
@@ -35,6 +36,7 @@ STATUS_FORCELIST = (500, 502, 503, 504)
 DEFAULT_CHUNK_SIZE = 65536  # 64KB
 
 
+@functools.cache
 def _get_user_agent() -> str:
     """
     Build a descriptive User-Agent string identifying hermeto to remote servers.
@@ -52,8 +54,6 @@ def _get_user_agent() -> str:
         version = "unknown"
     return f"{APP_NAME}/{version} (+https://github.com/hermetoproject/hermeto)"
 
-
-USER_AGENT: str = _get_user_agent()
 
 log = logging.getLogger(__name__)
 
@@ -107,7 +107,7 @@ def _get_pkg_requests_session() -> requests.Session:
     if _pkg_requests_session is None:
         max_retries = get_config().http.max_retries
         _pkg_requests_session = Session()
-        _pkg_requests_session.headers["User-Agent"] = USER_AGENT
+        _pkg_requests_session.headers["User-Agent"] = _get_user_agent()
         adapter = HTTPAdapter(
             max_retries=SyncLoggingRetry(
                 backoff_factor=BACKOFF_FACTOR,
@@ -280,7 +280,7 @@ async def async_download_files(
         trust_env=True,
         # preserve percent-encoding in redirect URLs (e.g. signed CloudFront URLs)
         requote_redirect_url=False,
-        headers={"User-Agent": USER_AGENT},
+        headers={"User-Agent": _get_user_agent()},
     )
 
     async with retry_client as session:

--- a/hermeto/core/package_managers/general.py
+++ b/hermeto/core/package_managers/general.py
@@ -193,7 +193,7 @@ async def _async_download_binary_file(
             timeout=timeout,
             raise_for_status=True,
             ssl=ssl_context,
-            headers={**(headers or {}), "User-Agent": _get_user_agent()},
+            headers=(headers or {}) | {"User-Agent": _get_user_agent()},
         ) as response:
             async with aiofiles.open(download_path, "wb") as f:
                 async for chunk in response.content.iter_chunked(chunk_size):

--- a/tests/unit/package_managers/test_general.py
+++ b/tests/unit/package_managers/test_general.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import asyncio
+import importlib.metadata
 import random
 from collections.abc import AsyncGenerator
 from pathlib import Path
@@ -20,6 +21,7 @@ from hermeto.core.package_managers import general
 from hermeto.core.package_managers.general import (
     _async_download_binary_file,
     _get_pkg_requests_session,
+    _get_user_agent,
     async_download_files,
     download_binary_file,
 )
@@ -78,6 +80,63 @@ def test_max_retries_propagated_to_session(monkeypatch: pytest.MonkeyPatch) -> N
     adapter = session.get_adapter("https://example.com")
     assert isinstance(adapter, HTTPAdapter)
     assert adapter.max_retries.total == 7
+
+
+def test_get_user_agent() -> None:
+    """The User-Agent must identify hermeto by name, version, and project URL."""
+    with mock.patch("importlib.metadata.version", return_value="1.2.3"):
+        user_agent = _get_user_agent()
+
+    assert user_agent == f"{general.APP_NAME}/1.2.3 (+https://github.com/hermetoproject/hermeto)"
+
+
+def test_get_user_agent_falls_back_when_package_not_found() -> None:
+    """Building the User-Agent must not fail if hermeto's own package metadata is missing.
+
+    This can happen when hermeto is run from source without being installed (e.g. `python -m`
+    against a checkout with no matching dist-info).
+    """
+    with mock.patch(
+        "importlib.metadata.version",
+        side_effect=importlib.metadata.PackageNotFoundError,
+    ):
+        user_agent = _get_user_agent()
+
+    assert user_agent == f"{general.APP_NAME}/unknown (+https://github.com/hermetoproject/hermeto)"
+
+
+def test_pkg_requests_session_sends_custom_user_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Requests must identify themselves as hermeto, not as the default python-requests UA.
+
+    Some package registries block the generic library-default User-Agent as a suspected
+    scraper/bot signature (see https://central.sonatype.org/faq/429-tooling-provider/).
+    """
+    monkeypatch.setattr("hermeto.core.package_managers.general._pkg_requests_session", None)
+    monkeypatch.setattr("hermeto.core.package_managers.general.USER_AGENT", "hermeto/test-ua")
+
+    session = _get_pkg_requests_session()
+
+    assert session.headers["User-Agent"] == "hermeto/test-ua"
+
+
+@pytest.mark.asyncio
+@mock.patch("hermeto.core.package_managers.general.aiohttp_retry.RetryClient")
+async def test_async_download_files_sends_custom_user_agent(
+    mock_retry_client: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """aiohttp downloads must identify themselves as hermeto, not as the default aiohttp UA.
+
+    Some package registries block the generic library-default User-Agent as a suspected
+    scraper/bot signature (see https://central.sonatype.org/faq/429-tooling-provider/).
+    """
+    monkeypatch.setattr("hermeto.core.package_managers.general.USER_AGENT", "hermeto/test-ua")
+    mock_session = mock_retry_client.return_value
+    mock_session.__aenter__.return_value = MagicMock()
+
+    await async_download_files({}, concurrency_limit=1)
+
+    assert mock_retry_client.call_args.kwargs["headers"] == {"User-Agent": "hermeto/test-ua"}
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/package_managers/test_general.py
+++ b/tests/unit/package_managers/test_general.py
@@ -84,8 +84,7 @@ def test_max_retries_propagated_to_session(monkeypatch: pytest.MonkeyPatch) -> N
 def test_pkg_requests_session_sends_custom_user_agent(
     mock_get_user_agent: MagicMock, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Requests must identify themselves as hermeto, not as the default python-requests UA.
-    """
+    """Requests must identify themselves as hermeto, not as the default python-requests UA."""
     monkeypatch.setattr("hermeto.core.package_managers.general._pkg_requests_session", None)
 
     session = _get_pkg_requests_session()
@@ -100,8 +99,7 @@ async def test_async_download_files_sends_custom_user_agent(
     mock_retry_client: MagicMock,
     mock_get_user_agent: MagicMock,
 ) -> None:
-    """aiohttp downloads must identify themselves as hermeto, not as the default aiohttp UA.
-    """
+    """aiohttp downloads must identify themselves as hermeto, not as the default aiohttp UA."""
     mock_session = mock_retry_client.return_value
     mock_session.__aenter__.return_value = MagicMock()
 
@@ -224,8 +222,44 @@ async def test_async_download_binary_file(tmp_path: Path) -> None:
         timeout=aiohttp.ClientTimeout(total=None, connect=30, sock_read=300),
         raise_for_status=True,
         ssl=None,
-        headers=None,
+        headers={"User-Agent": general._get_user_agent()},
     )
+
+
+@pytest.mark.asyncio
+async def test_async_download_binary_file_user_agent_not_overridable(tmp_path: Path) -> None:
+    """Per-URL headers must not be able to override hermeto's User-Agent.
+
+    aiohttp gives per-request headers precedence over session defaults, so a caller-supplied
+    "User-Agent" in the per-URL headers dict (e.g. auth headers assembled by a backend) would
+    otherwise silently replace hermeto's own identification.
+    """
+    url = "http://example.com/file.tar"
+    download_path = tmp_path / "file.tar"
+
+    async def mock_iter_chunked(size: int) -> AsyncGenerator[bytes, None]:
+        yield b"chunk-"
+
+    response, session = MagicMock(), MagicMock()
+    response.content.iter_chunked = mock_iter_chunked
+
+    async def mock_aenter() -> MagicMock:
+        return response
+
+    session.get().__aenter__.side_effect = mock_aenter
+
+    await _async_download_binary_file(
+        session,
+        url,
+        download_path,
+        headers={"User-Agent": "caller-supplied-ua", "Authorization": "token"},
+        ssl_context=None,
+    )
+
+    assert session.get.call_args.kwargs["headers"] == {
+        "User-Agent": general._get_user_agent(),
+        "Authorization": "token",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/package_managers/test_general.py
+++ b/tests/unit/package_managers/test_general.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import asyncio
-import importlib.metadata
 import random
 from collections.abc import AsyncGenerator
 from pathlib import Path
@@ -21,7 +20,6 @@ from hermeto.core.package_managers import general
 from hermeto.core.package_managers.general import (
     _async_download_binary_file,
     _get_pkg_requests_session,
-    _get_user_agent,
     async_download_files,
     download_binary_file,
 )
@@ -82,37 +80,13 @@ def test_max_retries_propagated_to_session(monkeypatch: pytest.MonkeyPatch) -> N
     assert adapter.max_retries.total == 7
 
 
-def test_get_user_agent() -> None:
-    """The User-Agent must identify hermeto by name, version, and project URL."""
-    with mock.patch("importlib.metadata.version", return_value="1.2.3"):
-        user_agent = _get_user_agent()
-
-    assert user_agent == f"{general.APP_NAME}/1.2.3 (+https://github.com/hermetoproject/hermeto)"
-
-
-def test_get_user_agent_falls_back_when_package_not_found() -> None:
-    """Building the User-Agent must not fail if hermeto's own package metadata is missing.
-
-    This can happen when hermeto is run from source without being installed (e.g. `python -m`
-    against a checkout with no matching dist-info).
-    """
-    with mock.patch(
-        "importlib.metadata.version",
-        side_effect=importlib.metadata.PackageNotFoundError,
-    ):
-        user_agent = _get_user_agent()
-
-    assert user_agent == f"{general.APP_NAME}/unknown (+https://github.com/hermetoproject/hermeto)"
-
-
-def test_pkg_requests_session_sends_custom_user_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+@mock.patch("hermeto.core.package_managers.general._get_user_agent", return_value="hermeto/test-ua")
+def test_pkg_requests_session_sends_custom_user_agent(
+    mock_get_user_agent: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Requests must identify themselves as hermeto, not as the default python-requests UA.
-
-    Some package registries block the generic library-default User-Agent as a suspected
-    scraper/bot signature (see https://central.sonatype.org/faq/429-tooling-provider/).
     """
     monkeypatch.setattr("hermeto.core.package_managers.general._pkg_requests_session", None)
-    monkeypatch.setattr("hermeto.core.package_managers.general.USER_AGENT", "hermeto/test-ua")
 
     session = _get_pkg_requests_session()
 
@@ -120,17 +94,14 @@ def test_pkg_requests_session_sends_custom_user_agent(monkeypatch: pytest.Monkey
 
 
 @pytest.mark.asyncio
+@mock.patch("hermeto.core.package_managers.general._get_user_agent", return_value="hermeto/test-ua")
 @mock.patch("hermeto.core.package_managers.general.aiohttp_retry.RetryClient")
 async def test_async_download_files_sends_custom_user_agent(
     mock_retry_client: MagicMock,
-    monkeypatch: pytest.MonkeyPatch,
+    mock_get_user_agent: MagicMock,
 ) -> None:
     """aiohttp downloads must identify themselves as hermeto, not as the default aiohttp UA.
-
-    Some package registries block the generic library-default User-Agent as a suspected
-    scraper/bot signature (see https://central.sonatype.org/faq/429-tooling-provider/).
     """
-    monkeypatch.setattr("hermeto.core.package_managers.general.USER_AGENT", "hermeto/test-ua")
     mock_session = mock_retry_client.return_value
     mock_session.__aenter__.return_value = MagicMock()
 


### PR DESCRIPTION
`hermeto` never set a User-Agent, so requests/aiohttp fell back to their library defaults (`python-requests/2.34.2`, `Python/3.12 aiohttp/3.14.1`). These defaults can be treated as bot/scraper signature by Maven Central and block it. Moreover, Sonatype Central also blocks the IP corresponding to that user agent for a day once this is triggered. This is also documented here: https://central.sonatype.org/faq/429-tooling-provider/#identify-your-tool-in-the-user-agent
