### PR TITLE
Refactor/rooted path pathlib interface

### DIFF
--- a/hermeto/core/models/input.py
+++ b/hermeto/core/models/input.py
@@ -469,7 +469,7 @@ class Request(pydantic.BaseModel):
                     raise ValueError(
                         f"package path (a symlink?) leads outside source directory: {p.path}"
                     )
-                if not abspath.path.is_dir():
+                if not abspath.is_dir():
                     raise ValueError(
                         f"package path does not exist (or is not a directory): {p.path}"
                     )

--- a/hermeto/core/package_managers/bundler/gem_models.py
+++ b/hermeto/core/package_managers/bundler/gem_models.py
@@ -178,7 +178,7 @@ class GitDependency(_GemMetadata):
         short_ref = self.ref[:short_ref_length]
 
         git_repo_path = deps_dir.join_within_root(f"{self.repo_name}-{short_ref}")
-        if git_repo_path.path.exists():
+        if git_repo_path.exists():
             log.info("Skipping existing git repository %s", self.url)
             return
 

--- a/hermeto/core/package_managers/bundler/parser.py
+++ b/hermeto/core/package_managers/bundler/parser.py
@@ -33,9 +33,9 @@ ParseResult = list[BundlerDependency]
 def _ensure_bundler_files_exist(package_dir: RootedPath) -> None:
     lockfile_path = package_dir.join_within_root(GEMFILE_LOCK)
     gemfile_path = package_dir.join_within_root(GEMFILE)
-    if not lockfile_path.path.exists() or not gemfile_path.path.exists():
+    if not lockfile_path.exists() or not gemfile_path.exists():
         raise LockfileNotFound(
-            files=lockfile_path.path if not lockfile_path.path.exists() else gemfile_path.path,
+            files=lockfile_path.path if not lockfile_path.exists() else gemfile_path.path,
         )
 
 
@@ -84,7 +84,7 @@ def parse_lockfile(
     json_output = _run_lockfile_parser(package_dir.path)
 
     bundler_version: str = json_output["bundler_version"]
-    log.info("Package %s is bundled with version %s", package_dir.path.name, bundler_version)
+    log.info("Package %s is bundled with version %s", package_dir.name, bundler_version)
     dependencies: list[dict[str, Any]] = json_output["dependencies"]
 
     result: ParseResult = []

--- a/hermeto/core/package_managers/cargo/main.py
+++ b/hermeto/core/package_managers/cargo/main.py
@@ -275,7 +275,7 @@ def _resolve_main_package(package_dir: RootedPath) -> tuple[str, str | None]:
     workspace_info = parsed_toml.get("workspace", {})
 
     # use default values if the project is a virtual workspace without any package information
-    name = package_info.get("name", package_dir.path.stem)
+    name = package_info.get("name", package_dir.stem)
     version = package_info.get("version", None)
 
     # check for a workspace package version
@@ -420,7 +420,7 @@ def _sanitized_cargo_config_file(package_dir: RootedPath) -> Generator[None, Non
 
     for cfgname in all_possible_config_names:
         config = package_dir.join_within_root(cfgname)
-        if config.path.exists():
+        if config.exists():
             data = config.path.read_text()
             sanitized = _sanitize_cargo_config(data)
 
@@ -623,7 +623,7 @@ def _generate_sbom_components(
     # swapped to point at the output directory. Check if source_dir is inside output_dir
     # to detect this scenario, where we can't expect a git repository (and flip the boolean
     # for readbility).
-    source_is_outside_output = not request.source_dir.path.is_relative_to(request.output_dir.path)
+    source_is_outside_output = not request.source_dir.is_relative_to(request.output_dir.path)
 
     # Missing git repo is tolerated in two independent cases:
     # 1. PERMISSIVE mode: validation is relaxed
@@ -654,7 +654,7 @@ def _generate_sbom_components(
                         name=main_package_name,
                         version=main_package_version,
                         vcs_url=vcs_url,
-                        subpath=str(package_dir.path.relative_to(package_dir.root)),
+                        subpath=str(package_dir.relative_to(package_dir.root)),
                     ).to_component()
                 )
 

--- a/hermeto/core/package_managers/gomod/main.py
+++ b/hermeto/core/package_managers/gomod/main.py
@@ -826,7 +826,7 @@ def _resolve_gomod(
     :raises PackageManagerError: if fetching dependencies fails
     """
     _protect_against_symlinks(app_dir)
-    should_vendor = app_dir.join_within_root("vendor").path.is_dir()
+    should_vendor = app_dir.join_within_root("vendor").is_dir()
 
     with TemporaryDirectory() as temp_netrc_dir:
         run_params = _prepare_run_params(
@@ -964,7 +964,7 @@ def _parse_go_sum(go_sum: RootedPath) -> frozenset[ModuleID]:
     A module is considered present if the checksum for its .zip file is present. The go.mod file
     checksums are not relevant for our purposes.
     """
-    if not go_sum.path.exists():
+    if not go_sum.exists():
         return frozenset()
 
     modules: list[ModuleID] = []
@@ -1169,7 +1169,7 @@ class ModuleVersionResolver:
         if app_dir.path == app_dir.root:
             subpath = None
         else:
-            subpath = app_dir.path.relative_to(app_dir.root).as_posix()
+            subpath = app_dir.relative_to(app_dir.root).as_posix()
 
         tag_on_commit = self._get_highest_semver_tag_on_current_commit(
             major_versions_to_try, subpath
@@ -1370,7 +1370,7 @@ def _validate_local_replacements(modules: Iterable[ParsedModule], app_path: Root
 def _parse_vendor(context_dir: RootedPath) -> Iterable[ParsedModule]:
     """Parse modules from vendor/modules.txt."""
     modules_txt = context_dir.join_within_root("vendor", "modules.txt")
-    if not modules_txt.path.exists():
+    if not modules_txt.exists():
         return []
 
     def fail_for_unexpected_format(msg: str) -> NoReturn:

--- a/hermeto/core/package_managers/javascript/npm/resolver.py
+++ b/hermeto/core/package_managers/javascript/npm/resolver.py
@@ -280,7 +280,7 @@ def _resolve_npm(pkg_path: RootedPath, npm_deps_dir: RootedPath) -> ResolvedNpmP
     # https://docs.npmjs.com/files/package-lock.json.
     for lock_file in ("npm-shrinkwrap.json", "package-lock.json"):
         package_lock_path = pkg_path.join_within_root(lock_file)
-        if package_lock_path.path.exists():
+        if package_lock_path.exists():
             break
     else:
         raise LockfileNotFound(
@@ -292,7 +292,7 @@ def _resolve_npm(pkg_path: RootedPath, npm_deps_dir: RootedPath) -> ResolvedNpmP
         )
 
     node_modules_path = pkg_path.join_within_root("node_modules")
-    if node_modules_path.path.exists():
+    if node_modules_path.exists():
         raise PackageRejected(
             "The 'node_modules' directory cannot be present in the source repository",
             solution="Ensure that there are no 'node_modules' directories in your repo",

--- a/hermeto/core/package_managers/javascript/yarn/main.py
+++ b/hermeto/core/package_managers/javascript/yarn/main.py
@@ -98,7 +98,7 @@ def _check_zero_installs(project: Project) -> None:
 
 def _check_lockfile(project: Project) -> None:
     lockfile_filename = project.yarn_rc.get("lockfileFilename", "yarn.lock")
-    if not project.source_dir.join_within_root(lockfile_filename).path.exists():
+    if not project.source_dir.join_within_root(lockfile_filename).exists():
         raise LockfileNotFound(
             files=project.source_dir.join_within_root(lockfile_filename).path,
         )

--- a/hermeto/core/package_managers/javascript/yarn/project.py
+++ b/hermeto/core/package_managers/javascript/yarn/project.py
@@ -94,14 +94,14 @@ class Project(NamedTuple):
         """
         node_linker = self.yarn_rc.get("nodeLinker")
         if node_linker is None or node_linker == "pnp":
-            if self.yarn_cache.path.exists() and self.yarn_cache.path.is_dir():
+            if self.yarn_cache.exists() and self.yarn_cache.is_dir():
                 # in this case the cache folder will be populated with downloaded ZIP dependencies
                 return any(file.suffix == ".zip" for file in self.yarn_cache.path.iterdir())
 
         elif node_linker == "pnpm" or node_linker == "node-modules":
             # in this case the cache may or may not be populated with ZIP files because an expanded
             # node_modules directory tree just like with NPM is enough for zero installs to work
-            return self.source_dir.join_within_root("node_modules").path.exists()
+            return self.source_dir.join_within_root("node_modules").exists()
 
         return False
 
@@ -119,7 +119,7 @@ class Project(NamedTuple):
         """Create a Project from a sources directory path."""
         yarn_rc_path = source_dir.join_within_root(".yarnrc.yml")
 
-        if yarn_rc_path.path.exists():
+        if yarn_rc_path.exists():
             yarn_rc = YarnRc.from_file(yarn_rc_path)
         else:
             yarn_rc = YarnRc(yarn_rc_path, {})

--- a/hermeto/core/package_managers/javascript/yarn/resolver.py
+++ b/hermeto/core/package_managers/javascript/yarn/resolver.py
@@ -443,7 +443,7 @@ class _ComponentResolver:
                     "expected a zip archive in the cache but 'yarn info' says there is none",
                 )
             cache_path = self._cache_path_as_rooted(package.cache_path)
-            if not cache_path.path.exists():
+            if not cache_path.exists():
                 raise _CouldNotResolve(
                     f"cache archive does not exist: {cache_path.subpath_from_root}"
                 )
@@ -456,7 +456,7 @@ class _ComponentResolver:
             packjson = self._project_subpath(
                 parent_locator.relpath, locator.relpath, "package.json"
             )
-            if isinstance(locator, LinkLocator) and not packjson.path.exists():
+            if isinstance(locator, LinkLocator) and not packjson.exists():
                 # if a link dependency doesn't have a package.json, we have to rely on the locator
                 name = self._scoped_name(locator)
                 version = None

--- a/hermeto/core/package_managers/javascript/yarn_classic/project.py
+++ b/hermeto/core/package_managers/javascript/yarn_classic/project.py
@@ -74,7 +74,7 @@ class Project:
         pnp_enabled = install_config.get("pnp", False)
 
         pnp_cjs_exists = any(self.source_dir.path.glob("*.pnp.cjs"))
-        node_modules_exists = self.source_dir.join_within_root("node_modules").path.exists()
+        node_modules_exists = self.source_dir.join_within_root("node_modules").exists()
         return pnp_enabled or pnp_cjs_exists or node_modules_exists
 
     @classmethod

--- a/hermeto/core/package_managers/javascript/yarn_classic/workspaces.py
+++ b/hermeto/core/package_managers/javascript/yarn_classic/workspaces.py
@@ -85,7 +85,7 @@ def extract_workspace_metadata(package_path: RootedPath) -> list[Workspace]:
 
         # Ignore "workspaces" with missing package.json
         # https://github.com/yarnpkg/yarn/blob/7cafa512a777048ce0b666080a24e80aae3d66a9/src/config.js#L833
-        if not package_json_path.path.exists():
+        if not package_json_path.exists():
             log.warning(
                 (
                     "The Yarn workspace located at %s does not contain a "

--- a/hermeto/core/package_managers/python/pip/main.py
+++ b/hermeto/core/package_managers/python/pip/main.py
@@ -553,7 +553,7 @@ def _download_from_requirement_files(
     """
     requirements: list[PipPackage] = []
     for req_file in files:
-        if not req_file.path.exists():
+        if not req_file.exists():
             raise LockfileNotFound(
                 files=req_file.path,
                 solution="Please check that you have specified correct requirements file paths",
@@ -575,7 +575,7 @@ def _default_requirement_file_list(path: RootedPath, devel: bool = False) -> lis
     """
     filename = DEFAULT_BUILD_REQUIREMENTS_FILE if devel else DEFAULT_REQUIREMENTS_FILE
     req = path.join_within_root(filename)
-    return [req] if req.path.is_file() else []
+    return [req] if req.is_file() else []
 
 
 def _resolve_pip(

--- a/hermeto/core/package_managers/python/pip/project_files.py
+++ b/hermeto/core/package_managers/python/pip/project_files.py
@@ -103,7 +103,7 @@ class SetupFile(ABC):
 
     def exists(self) -> bool:
         """Check if file exists."""
-        return self._setup_file.path.is_file()
+        return self._setup_file.is_file()
 
     @abstractmethod
     def get_name(self) -> str | None:
@@ -265,7 +265,7 @@ class SetupCFG(SetupFile):
     def _read_version_from_file(self, file_path: str) -> str | None:
         """Read version from file."""
         version_file = self._top_dir.join_within_root(file_path)
-        if version_file.path.is_file():
+        if version_file.is_file():
             version = version_file.path.read_text().strip()
             log.debug("Read version from %r: %r", file_path, version)
             return version
@@ -300,7 +300,7 @@ class SetupCFG(SetupFile):
             return None
 
         try:
-            module_ast = ast.parse(module_file.path.read_text(), module_file.path.name)
+            module_ast = ast.parse(module_file.path.read_text(), module_file.name)
         except SyntaxError as e:
             log.error("Syntax error when parsing module: %s", e)
             return None
@@ -339,11 +339,11 @@ class SetupCFG(SetupFile):
             module_path = custom_path / module_path
 
         package_init = self._top_dir.join_within_root(module_path).join_within_root("__init__.py")
-        if package_init.path.is_file():
+        if package_init.is_file():
             return package_init
 
         module_py = self._top_dir.join_within_root(f"{module_path}.py")
-        if module_py.path.is_file():
+        if module_py.is_file():
             return module_py
 
         return None

--- a/hermeto/core/package_managers/python/pip/rust.py
+++ b/hermeto/core/package_managers/python/pip/rust.py
@@ -37,7 +37,7 @@ def _depends_on_rust(extracted_dir: Path) -> bool:
     }
 
     for file, get_build_deps_method in python_files_map.items():
-        if not root.join_within_root(file).path.exists():
+        if not root.join_within_root(file).exists():
             continue
 
         build_deps = get_build_deps_method()

--- a/hermeto/core/package_managers/rpm/main.py
+++ b/hermeto/core/package_managers/rpm/main.py
@@ -283,7 +283,7 @@ def _resolve_rpm_project(
     ssl_options = options.ssl if options and options.ssl else None
 
     # Check the availability of the input lockfile.
-    if not source_dir.join_within_root(DEFAULT_LOCKFILE_NAME).path.exists():
+    if not source_dir.join_within_root(DEFAULT_LOCKFILE_NAME).exists():
         raise LockfileNotFound(
             files=source_dir.join_within_root(DEFAULT_LOCKFILE_NAME).path,
         )

--- a/hermeto/core/resolver.py
+++ b/hermeto/core/resolver.py
@@ -66,7 +66,7 @@ def resolve_packages(request: Request) -> RequestOutput:
         for project_file in output.build_config.project_files:
             try:
                 subpath = project_file.abspath.relative_to(source_backup)
-                project_file.abspath = original_source_dir / subpath
+                project_file.abspath = (original_source_dir / subpath).path
             except ValueError:
                 # '<project_file.abspath> is not in the subpath of <source_backup>', i.e the file
                 # is referenced directly from the output directory and doesn't need replacing

--- a/hermeto/core/rooted_path.py
+++ b/hermeto/core/rooted_path.py
@@ -34,6 +34,9 @@ class RootedPath(os.PathLike[str]):
     The join_within_root method remembers the original root. See the join_within_root
     and re_root docstrings for more details.
 
+    Exposes common Path queries (exists, is_dir, name, stem, etc.) directly so
+    callers need not reach through the .path accessor for everyday operations.
+
     Implements the PathLike interface -> most stdlib methods that accept paths will work
     with a RootedPath as well.
 
@@ -87,6 +90,49 @@ class RootedPath(os.PathLike[str]):
 
     def __hash__(self) -> int:
         return hash((self._path, self._root))
+
+    # Read-only Path operations that cannot escape the root boundary.
+    # Mutating or navigating operations (e.g. parent, rename, iterdir)
+    # are deliberately excluded.
+
+    @property
+    def name(self) -> str:
+        """Return the final component of the path."""
+        return self._path.name
+
+    @property
+    def stem(self) -> str:
+        """Return the final component without its suffix."""
+        return self._path.stem
+
+    @property
+    def suffix(self) -> str:
+        """Return the file extension of the final component."""
+        return self._path.suffix
+
+    def exists(self) -> bool:
+        """Return whether the path points to an existing filesystem entry."""
+        return self._path.exists()
+
+    def is_dir(self) -> bool:
+        """Return whether the path points to a directory."""
+        return self._path.is_dir()
+
+    def is_file(self) -> bool:
+        """Return whether the path points to a regular file."""
+        return self._path.is_file()
+
+    def is_relative_to(self, other: StrPath) -> bool:
+        """Return whether this path is relative to *other*."""
+        return self._path.is_relative_to(other)
+
+    def relative_to(self, other: StrPath) -> Path:
+        """Return a relative version of this path against *other*."""
+        return self._path.relative_to(other)
+
+    def as_posix(self) -> str:
+        """Return the path as a POSIX string."""
+        return self._path.as_posix()
 
     def re_root(self: RootedPathT, *other: StrPath) -> RootedPathT:
         """Safely join other path components and make the result the new root.

--- a/hermeto/core/rooted_path.py
+++ b/hermeto/core/rooted_path.py
@@ -91,6 +91,10 @@ class RootedPath(os.PathLike[str]):
     def __hash__(self) -> int:
         return hash((self._path, self._root))
 
+    def __truediv__(self: RootedPathT, other: StrPath) -> RootedPathT:
+        """Join via ``join_within_root``; raises PathOutsideRoot on escape."""
+        return self.join_within_root(other)
+
     # Read-only Path operations that cannot escape the root boundary.
     # Mutating or navigating operations (e.g. parent, rename, iterdir)
     # are deliberately excluded.

--- a/tests/unit/package_managers/rpm/test_main.py
+++ b/tests/unit/package_managers/rpm/test_main.py
@@ -34,7 +34,7 @@ def test_resolve_rpm_project_no_lockfile(rooted_tmp_path: RootedPath) -> None:
     with pytest.raises(LockfileNotFound):
         # MagicMock is to pass Path/str to LockfileNotFound and avoid TypeError
         mock_source_dir = mock.MagicMock()
-        mock_source_dir.join_within_root.return_value.path.exists.return_value = False
+        mock_source_dir.join_within_root.return_value.exists.return_value = False
         _resolve_rpm_project(mock_source_dir, mock.Mock())
 
 

--- a/tests/unit/test_rooted_path.py
+++ b/tests/unit/test_rooted_path.py
@@ -123,6 +123,32 @@ def test_rooted_path_eq() -> None:
     assert a == RootedPath("/some/directory").join_within_root("subpath")
 
 
+class TestTruediv:
+    """The / operator must behave identically to join_within_root."""
+
+    def test_basic_join(self, test_path: Path) -> None:
+        rp = RootedPath(test_path)
+        result = rp / "subpath"
+        assert_attrs(result, path=test_path / "subpath", root=test_path)
+
+    def test_chained_join(self, test_path: Path) -> None:
+        rp = RootedPath(test_path)
+        result = rp / "subpath" / ".."
+        assert_attrs(result, path=test_path, root=test_path)
+
+    @pytest.mark.parametrize(
+        "subpath",
+        [
+            pytest.param("..", id="parent-escape"),
+            pytest.param("/abspath", id="absolute-path"),
+            pytest.param("symlink-to-parent", id="symlink-escape"),
+        ],
+    )
+    def test_rejects_outside_root(self, test_path: Path, subpath: str) -> None:
+        with pytest.raises(PathOutsideRoot):
+            RootedPath(test_path) / subpath
+
+
 @pytest.mark.parametrize(
     "attr",
     [

--- a/tests/unit/test_rooted_path.py
+++ b/tests/unit/test_rooted_path.py
@@ -123,6 +123,34 @@ def test_rooted_path_eq() -> None:
     assert a == RootedPath("/some/directory").join_within_root("subpath")
 
 
+@pytest.mark.parametrize(
+    "attr",
+    [
+        pytest.param("name", id="name"),
+        pytest.param("stem", id="stem"),
+        pytest.param("suffix", id="suffix"),
+        pytest.param("exists", id="exists"),
+        pytest.param("is_dir", id="is_dir"),
+        pytest.param("is_file", id="is_file"),
+        pytest.param("as_posix", id="as_posix"),
+    ],
+)
+def test_passthrough_matches_inner_path(test_path: Path, attr: str) -> None:
+    rp = RootedPath(test_path)
+    rp_val = getattr(rp, attr)
+    path_val = getattr(test_path, attr)
+    if callable(rp_val):
+        assert rp_val() == path_val()
+    else:
+        assert rp_val == path_val
+
+
+def test_relative_to(test_path: Path) -> None:
+    rp = RootedPath(test_path).join_within_root("subpath")
+    assert rp.relative_to(test_path) == Path("subpath")
+    assert rp.is_relative_to(test_path)
+
+
 def test_pydantic_integration() -> None:
     class SomeModel(pydantic.BaseModel):
         path: RootedPath


### PR DESCRIPTION
## Summary
- Add `__truediv__` (`/` operator), read-only properties (`name`, `stem`,
  `suffix`) and query methods (`exists`, `is_dir`, `is_file`,
  `is_relative_to`, `relative_to`, `as_posix`) to `RootedPath`
- Migrate existing callsites to use the new interface