### PR TITLE
fix(core): retry source tree copy racing git gc

### DIFF
--- a/hermeto/core/resolver.py
+++ b/hermeto/core/resolver.py
@@ -18,6 +18,7 @@ from hermeto.core.package_managers import (
 from hermeto.core.package_managers.javascript import metayarn, npm, pnpm
 from hermeto.core.package_managers.python import pip
 from hermeto.core.rooted_path import RootedPath
+from hermeto.core.scm import repo_head_resolves
 from hermeto.core.utils import copy_directory
 
 Handler = Callable[[Request], RequestOutput]
@@ -46,6 +47,21 @@ def get_experimental_backends() -> list[PackageManagerType | str]:
     return sorted(x for x in _package_managers if x.startswith("x-"))
 
 
+def _source_copy_validator(original: Path) -> Callable[[Path], bool]:
+    """Build a validator that rejects a source copy which lost a resolvable HEAD to the copy race.
+
+    A copy racing a concurrent 'git gc' on the source can end up with an inconsistent .git whose
+    HEAD no longer resolves, in which case copy_directory retries. The validator only checks HEAD,
+    not the whole object graph: a full 'git fsck' would run O(repo) on every request with a .git,
+    including ecosystems that never read git history.
+
+    The check is only enforced when the original HEAD resolves, so a non-git or commit-less source
+    is not rejected for an unresolvable HEAD it never had.
+    """
+    original_resolves = repo_head_resolves(original)
+    return lambda copy: not original_resolves or repo_head_resolves(copy)
+
+
 def resolve_packages(request: Request) -> RequestOutput:
     """
     Resolve all packages specified in a request.
@@ -56,7 +72,11 @@ def resolve_packages(request: Request) -> RequestOutput:
     original_source_dir = request.source_dir
 
     with TemporaryDirectory(f".{APP_NAME}-source-copy", dir=original_source_dir.path) as temp_dir:
-        source_backup = copy_directory(original_source_dir.path, Path(temp_dir).resolve())
+        source_backup = copy_directory(
+            original_source_dir.path,
+            Path(temp_dir).resolve(),
+            is_valid=_source_copy_validator(original_source_dir.path),
+        )
 
         request.source_dir = RootedPath(source_backup)
         output = _resolve_packages(request)

--- a/hermeto/core/scm.py
+++ b/hermeto/core/scm.py
@@ -209,6 +209,20 @@ def get_repo_id(repo: StrPath | GitRepo | git.Repo) -> RepoID:
     return RepoID(url, commit_id)
 
 
+def repo_head_resolves(repo_path: StrPath) -> bool:
+    """Return whether the git repo at repo_path resolves HEAD to an existing commit.
+
+    A path that is not a git repository returns True: there is nothing to verify.
+    """
+    try:
+        GitRepo(repo_path).head.commit
+    except NotAGitRepo:
+        return True
+    except GitInvalidRevisionError:
+        return False
+    return True
+
+
 def _find_submodule_containing_path(repo: GitRepo, target_path: Path) -> git.Submodule | None:
     """Find the submodule containing the target path, if any.
 

--- a/hermeto/core/utils.py
+++ b/hermeto/core/utils.py
@@ -7,6 +7,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from collections.abc import Callable, Iterator, Sequence
 from functools import cache
 from pathlib import Path
@@ -166,14 +167,34 @@ def _fast_copy(src: Path, dest: Path) -> int:
     return total
 
 
-def copy_directory(origin: Path, destination: Path) -> Path:
+# A concurrent 'git gc' on the source repo can make a copy fail or copy an inconsistent .git.
+# Housekeeping is short-lived, so a few retries are enough to land on a clean tree.
+_COPY_MAX_ATTEMPTS = 5
+_COPY_RETRY_BACKOFF = 0.1
+
+
+def copy_directory(
+    origin: Path,
+    destination: Path,
+    is_valid: Callable[[Path], bool] = lambda _: True,
+) -> Path:
     """
     Recursively copy directory to another path.
 
     Use fast in-kernel copying (including reflink file system optimization) and fall back to
     regular copy if the former fails for some reason.
 
-    :raise FileExistsError: if the destination path already exists.
+    copytree first scans a directory and then copies each entry, so a process that mutates the tree
+    between those steps can make an entry disappear mid-copy. The usual cause is a concurrent
+    'git gc' on a source repo, which packs loose objects and refs and then removes the loose
+    originals. Such a race either raises shutil.Error or produces an inconsistent .git, so the copy
+    is retried until it succeeds.
+
+    :param is_valid: predicate run on a successful copy; returning False rejects the copy and
+        triggers another attempt. Callers copying a source repo use it to reject an inconsistent
+        .git that copied without raising. Defaults to accepting every copy.
+    :raise shutil.Error: if the copy keeps failing, or keeps validating as inconsistent, across
+        all retries.
     :raise FileNotFoundError: if the origin directory does not exist.
     """
 
@@ -187,15 +208,39 @@ def copy_directory(origin: Path, destination: Path) -> Path:
             ignore=shutil.ignore_patterns(destination.name),
         )
 
-    try:
-        log.debug("Copying %s to %s using fast in-kernel copy.", origin, destination)
-        _copy_using(_fast_copy)
-    except _FastCopyFailedFallback:
-        log.debug("Fast copying failed, falling back to standard copy.")
-        shutil.rmtree(destination)
-        _copy_using(shutil.copy2)
+    def _attempt() -> None:
+        # a previous attempt may have left a partial copy behind; start clean
+        if destination.exists():
+            shutil.rmtree(destination)
+        try:
+            log.debug("Copying %s to %s using fast in-kernel copy.", origin, destination)
+            _copy_using(_fast_copy)
+        except _FastCopyFailedFallback:
+            log.debug("Fast copying failed, falling back to standard copy.")
+            shutil.rmtree(destination)
+            _copy_using(shutil.copy2)
 
-    return destination
+    # Retry the copy while it keeps losing the race. On the last attempt a persistent failure
+    # propagates instead of silently returning a broken copy.
+    for attempt in range(_COPY_MAX_ATTEMPTS):
+        last_attempt = attempt == _COPY_MAX_ATTEMPTS - 1
+        try:
+            _attempt()
+        except shutil.Error:
+            if last_attempt:
+                raise  # lost every race, give up
+        else:
+            if is_valid(destination):
+                return destination
+            if last_attempt:
+                raise shutil.Error(
+                    f"Copy of {origin} failed validation after {_COPY_MAX_ATTEMPTS} attempts; "
+                    "the source tree kept changing during the copy."
+                )
+        log.debug("Source copy lost a race with git gc, retrying (attempt %d)", attempt + 1)
+        time.sleep(_COPY_RETRY_BACKOFF * (attempt + 1))
+
+    raise AssertionError("unreachable: the retry loop returns or raises on the last attempt")
 
 
 def get_cache_dir() -> Path:

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -55,9 +55,13 @@ class SyntheticRepo:
 
     _GIT_ENV = {
         **GIT_PRISTINE_ENV,
-        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_COUNT": "2",
         "GIT_CONFIG_KEY_0": "protocol.file.allow",
         "GIT_CONFIG_VALUE_0": "always",
+        # git runs 'git gc' in the background after a big commit; that races hermeto's copy of
+        # the repo and makes tests flaky, so turn it off.
+        "GIT_CONFIG_KEY_1": "gc.auto",
+        "GIT_CONFIG_VALUE_1": "0",
         "GIT_AUTHOR_NAME": "Test Author",
         "GIT_AUTHOR_EMAIL": "test@example.com",
         "GIT_COMMITTER_NAME": "Test Author",

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -170,6 +170,41 @@ def test_project_files_fix_for_work_copy(
     assert output.build_config.project_files[0].abspath == tmp_path / "package.json"
 
 
+@mock.patch("hermeto.core.resolver.repo_head_resolves")
+def test_source_copy_validator_accepts_consistent_copy(
+    mock_resolves: mock.Mock, tmp_path: Path
+) -> None:
+    # original resolves HEAD, so a copy that also resolves is accepted
+    mock_resolves.side_effect = [True, True]
+    validate = resolver._source_copy_validator(tmp_path)
+
+    assert validate(tmp_path / "copy") is True
+
+
+@mock.patch("hermeto.core.resolver.repo_head_resolves")
+def test_source_copy_validator_rejects_copy_that_lost_head(
+    mock_resolves: mock.Mock, tmp_path: Path
+) -> None:
+    # original resolves HEAD but the copy does not: the race dropped it, reject so it gets retried
+    mock_resolves.side_effect = [True, False]
+    validate = resolver._source_copy_validator(tmp_path)
+
+    assert validate(tmp_path / "copy") is False
+
+
+@mock.patch("hermeto.core.resolver.repo_head_resolves")
+def test_source_copy_validator_skips_when_original_has_no_head(
+    mock_resolves: mock.Mock, tmp_path: Path
+) -> None:
+    # a commit-less or non-git original never resolved HEAD, so its copy is accepted without
+    # re-checking
+    mock_resolves.side_effect = [False]
+    validate = resolver._source_copy_validator(tmp_path)
+
+    assert validate(tmp_path / "copy") is True
+    mock_resolves.assert_called_once_with(tmp_path)
+
+
 def test_resolve_with_multiple_stable_package_managers(tmp_path: Path) -> None:
     mock_resolve_gomod = mock.Mock(return_value=RequestOutput.empty())
     mock_resolve_pip = mock.Mock(return_value=RequestOutput.empty())

--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -9,7 +9,14 @@ import git
 import pytest
 
 from hermeto.core.errors import FetchError, NotAGitRepo, UnsupportedFeature
-from hermeto.core.scm import RepoID, clone_as_tarball, get_repo_for_path, get_repo_id
+from hermeto.core.rooted_path import RootedPath
+from hermeto.core.scm import (
+    RepoID,
+    clone_as_tarball,
+    get_repo_for_path,
+    get_repo_id,
+    repo_head_resolves,
+)
 
 INITIAL_COMMIT = "78510c591e2be635b010a52a7048b562bad855a3"
 
@@ -154,3 +161,23 @@ def test_get_repo_for_path(
         resolved_repo, resolved_relative_path = get_repo_for_path(main_repo_root, path_to_resolve)
         assert Path(resolved_repo.working_dir) == expected_repo_root
         assert resolved_relative_path == Path(expected_path_in_repo)
+
+
+def test_repo_head_resolves_non_git(tmp_path: Path) -> None:
+    # a path that is not a git repo has nothing to verify
+    assert repo_head_resolves(tmp_path) is True
+
+
+def test_repo_head_resolves_healthy_repo(rooted_tmp_path_repo: RootedPath) -> None:
+    assert repo_head_resolves(rooted_tmp_path_repo.path) is True
+
+
+def test_repo_head_resolves_unresolvable_head(rooted_tmp_path_repo: RootedPath) -> None:
+    # simulate a copy that raced git housekeeping: HEAD points to a branch whose ref no longer
+    # exists (loose file gone, never packed), leaving HEAD unresolvable
+    git_dir = rooted_tmp_path_repo.path / ".git"
+    (git_dir / "HEAD").write_text("ref: refs/heads/gone\n")
+    for ref in ("master", "main"):
+        (git_dir / "refs" / "heads" / ref).unlink(missing_ok=True)
+
+    assert repo_head_resolves(rooted_tmp_path_repo.path) is False

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 import errno
 import io
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -11,6 +12,7 @@ import pytest
 from hermeto import APP_NAME
 from hermeto.core.errors import ExecutableNotFound
 from hermeto.core.utils import (
+    _COPY_MAX_ATTEMPTS,
     _fast_copy,
     _FastCopyFailedFallback,
     copy_directory,
@@ -185,6 +187,105 @@ def test_copy_directory(
     # check we called both copy_functions (_fast_copy, copy2)
     mock_copy_range.assert_called_once()
     mock_shutil_copy2.assert_called_once()
+
+
+@mock.patch("time.sleep")
+@mock.patch("shutil.copytree")
+def test_copy_directory_retries_on_transient_error(
+    mock_copytree: mock.Mock,
+    mock_sleep: mock.Mock,
+    tmp_path: Path,
+) -> None:
+    """Test that a shutil.Error from a mid-copy mutation is retried and recovers."""
+    origin = tmp_path.joinpath("src")
+    origin.mkdir()
+    destination = tmp_path.joinpath("dst")
+
+    # first attempt leaves a partial copy behind then fails as if an entry vanished mid-copy; the
+    # retry cleans up that partial destination (the rmtree-before-attempt branch) and succeeds
+    def copytree(*args: object, **kwargs: object) -> None:
+        if mock_copytree.call_count == 1:
+            destination.mkdir()
+            destination.joinpath("partial").touch()
+            raise shutil.Error([("src", "dst", "vanished")])
+
+    mock_copytree.side_effect = copytree
+
+    assert copy_directory(origin, destination) == destination
+    assert mock_copytree.call_count == 2
+    assert not destination.joinpath("partial").exists()
+
+
+@mock.patch("time.sleep")
+@mock.patch("shutil.copytree")
+def test_copy_directory_recovers_on_final_attempt(
+    mock_copytree: mock.Mock,
+    mock_sleep: mock.Mock,
+    tmp_path: Path,
+) -> None:
+    """Test that a copy failing on every attempt but the last still succeeds."""
+    mock_copytree.side_effect = [shutil.Error([("src", "dst", "vanished")])] * (
+        _COPY_MAX_ATTEMPTS - 1
+    ) + [None]
+
+    origin = tmp_path.joinpath("src")
+    origin.mkdir()
+    destination = tmp_path.joinpath("dst")
+
+    assert copy_directory(origin, destination) == destination
+    assert mock_copytree.call_count == _COPY_MAX_ATTEMPTS
+
+
+@mock.patch("time.sleep")
+@mock.patch("shutil.copytree")
+def test_copy_directory_reraises_persistent_error(
+    mock_copytree: mock.Mock,
+    mock_sleep: mock.Mock,
+    tmp_path: Path,
+) -> None:
+    """Test that a copy failing on every attempt propagates the error."""
+    mock_copytree.side_effect = shutil.Error([("src", "dst", "boom")])
+
+    origin = tmp_path.joinpath("src")
+    origin.mkdir()
+
+    with pytest.raises(shutil.Error):
+        copy_directory(origin, tmp_path.joinpath("dst"))
+
+
+@mock.patch("time.sleep")
+@mock.patch("shutil.copytree")
+def test_copy_directory_retries_until_validation_passes(
+    mock_copytree: mock.Mock,
+    mock_sleep: mock.Mock,
+    tmp_path: Path,
+) -> None:
+    """Test that a copy validating as inconsistent is retried until validation passes."""
+    mock_copytree.return_value = None
+    is_valid = mock.Mock(side_effect=[False, False, True])
+
+    origin = tmp_path.joinpath("src")
+    origin.mkdir()
+
+    assert copy_directory(origin, tmp_path.joinpath("dst"), is_valid=is_valid) == tmp_path / "dst"
+    assert is_valid.call_count == 3
+
+
+@mock.patch("time.sleep")
+@mock.patch("shutil.copytree")
+def test_copy_directory_raises_when_validation_never_passes(
+    mock_copytree: mock.Mock,
+    mock_sleep: mock.Mock,
+    tmp_path: Path,
+) -> None:
+    """Test that a copy that never validates raises instead of returning silently."""
+    mock_copytree.return_value = None
+
+    origin = tmp_path.joinpath("src")
+    origin.mkdir()
+
+    with pytest.raises(shutil.Error):
+        copy_directory(origin, tmp_path.joinpath("dst"), is_valid=lambda _: False)
 
 
 @pytest.mark.parametrize("environ", [{"XDG_CACHE_HOME": "/tmp/xdg_home/"}, {}])


### PR DESCRIPTION
Before running a backend hermeto copies the source tree, including its `.git`, into a working copy. That copy isn't atomic, so a `git gc` running on the source repo can pull objects out from under it mid-copy. Usually the copy just crashes with a `shutil.Error`, but in the nasty case it finishes with a broken `.git` and no error at all, and an unresolvable HEAD then makes gomod quietly resolve the wrong module version.

Rather than skip whatever vanished (which would turn a loud crash into silent SBOM corruption), we retry the copy until git has settled and check that the copied repo still resolves HEAD. Our own integration tests tripped the same race when git's auto-gc fired on their test repo, so auto-gc is now disabled there.

See the commit messages for the details.

CI failure this fixes:
https://github.com/hermetoproject/hermeto/actions/runs/33869701229/job/101012505958